### PR TITLE
Feature/hostname redirect

### DIFF
--- a/Controllers/HostnameRedirectsController.cs
+++ b/Controllers/HostnameRedirectsController.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using OrchardCore.Entities;
+using OrchardCore.Modules;
+using OrchardCore.Settings;
+using System.Net.Mime;
+using System.Threading.Tasks;
+
+namespace Moov2.OrchardCore.SEO.Controllers
+{
+    [Feature("Moov2.OrchardCore.SEO.HostnameRedirects")]
+    public class HostnameRedirectsController : Controller
+    {
+        #region Dependencies
+
+        private readonly ISiteService _siteService;
+
+        #endregion
+
+        #region Constructor
+
+        public HostnameRedirectsController(ISiteService siteService)
+        {
+            _siteService = siteService;
+        }
+
+        #endregion
+
+        #region Actions
+
+        public async Task<IActionResult> Index()
+        {
+            return Content("", MediaTypeNames.Text.Plain);
+        }
+
+        #endregion
+    }
+}

--- a/HostnameRedirects/AdminMenu.cs
+++ b/HostnameRedirects/AdminMenu.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Localization;
+using Moov2.OrchardCore.SEO.HostnameRedirects.Drivers;
+using OrchardCore.Modules;
+using OrchardCore.Navigation;
+using System;
+using System.Threading.Tasks;
+
+namespace Moov2.OrchardCore.SEO.HostnameRedirects
+{
+    [Feature("Moov2.OrchardCore.SEO.HostnameRedirects")]
+    public class AdminMenu : INavigationProvider
+    {
+        public AdminMenu(IStringLocalizer<AdminMenu> localizer)
+        {
+            T = localizer;
+        }
+
+        public IStringLocalizer T { get; set; }
+
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
+        {
+            if (!string.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.CompletedTask;
+            }
+
+            builder
+                .Add(T["Configuration"], configuration => configuration
+                    .Add(T["SEO"], settings => settings
+                        .Add(T["Hostname Redirects"], T["Hostname Redirects"], layers => layers
+                            .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = HostnameRedirectsSettingsDisplayDriver.GroupId })
+                            .Permission(Permissions.ManageHostnameRedirects)
+                            .LocalNav()
+                        )));
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/HostnameRedirects/Drivers/HostnameRedirectsSettingsDisplayDriver.cs
+++ b/HostnameRedirects/Drivers/HostnameRedirectsSettingsDisplayDriver.cs
@@ -48,7 +48,10 @@ namespace Moov2.OrchardCore.SEO.HostnameRedirects.Drivers
 
             return Initialize<HostnameRedirectsSettingsViewModel>("HostnameRedirectsSettings_Edit", model =>
             {
-                model.Mode = settings.Mode;
+                model.Redirect = settings.Redirect;
+                model.ForceSSL = settings.ForceSSL;
+                model.RedirectToSiteUrl = settings.RedirectToSiteUrl;
+                model.IgnoredUrls = settings.IgnoredUrls;
             }).Location("Content:3").OnGroup(GroupId);
         }
 
@@ -67,7 +70,10 @@ namespace Moov2.OrchardCore.SEO.HostnameRedirects.Drivers
 
                 await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-                settings.Mode = model.Mode;
+                settings.Redirect = model.Redirect;
+                settings.ForceSSL = model.ForceSSL;
+                settings.RedirectToSiteUrl = model.RedirectToSiteUrl;
+                settings.IgnoredUrls = model.IgnoredUrls;
             }
 
             return await EditAsync(settings, context);

--- a/HostnameRedirects/Models/HostnameRedirectModes.cs
+++ b/HostnameRedirects/Models/HostnameRedirectModes.cs
@@ -1,0 +1,9 @@
+﻿namespace Moov2.OrchardCore.SEO.HostnameRedirects.Models {
+    public class HostnameRedirectModes
+    {
+        public const int None = 0;
+        public const int NonWWW = 1;
+        public const int WWW = 2;
+        public const int Domain = 3;
+    }
+}

--- a/HostnameRedirects/Models/HostnameRedirectsSettings.cs
+++ b/HostnameRedirects/Models/HostnameRedirectsSettings.cs
@@ -2,6 +2,9 @@
 {
     public class HostnameRedirectsSettings
     {
-        public int Mode { get; set; }
+        public int Redirect { get; set; }
+        public string RedirectToSiteUrl { get; set; }
+        public bool ForceSSL { get; set; }
+        public string IgnoredUrls { get; set; }
     }
 }

--- a/HostnameRedirects/Models/HostnameRedirectsSettings.cs
+++ b/HostnameRedirects/Models/HostnameRedirectsSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace Moov2.OrchardCore.SEO.HostnameRedirects.Models
+{
+    public class HostnameRedirectsSettings
+    {
+        public int Mode { get; set; }
+    }
+}

--- a/HostnameRedirects/Permissions.cs
+++ b/HostnameRedirects/Permissions.cs
@@ -1,0 +1,27 @@
+﻿using OrchardCore.Security.Permissions;
+using System.Collections.Generic;
+
+namespace Moov2.OrchardCore.SEO.HostnameRedirects
+{
+    public class Permissions : IPermissionProvider
+    {
+        public static readonly Permission ManageHostnameRedirects = new Permission("ManageHostnameRedirects", "Manage hostname redirects");
+
+        public IEnumerable<Permission> GetPermissions()
+        {
+            return new[] { ManageHostnameRedirects };
+        }
+
+        public IEnumerable<PermissionStereotype> GetDefaultStereotypes()
+        {
+            return new[]
+            {
+                new PermissionStereotype
+                {
+                    Name = "Administrator",
+                    Permissions = new[] { ManageHostnameRedirects }
+                }
+            };
+        }
+    }
+}

--- a/HostnameRedirects/Services/HostRedirectService.cs
+++ b/HostnameRedirects/Services/HostRedirectService.cs
@@ -1,0 +1,21 @@
+﻿using Moov2.OrchardCore.SEO.HostnameRedirects.Models;
+using OrchardCore.Entities;
+using OrchardCore.Settings;
+using System.Threading.Tasks;
+
+namespace Moov2.OrchardCore.SEO.HostnameRedirects.Services {
+
+    public class HostRedirectService : IHostRedirectService {
+        private readonly ISiteService _siteService;
+
+        public HostRedirectService(ISiteService siteService) {
+            _siteService = siteService;
+        }
+
+        public async Task<HostnameRedirectsSettings> GetSettingsAsync() {
+            var siteSettings = await _siteService.GetSiteSettingsAsync();
+            return siteSettings.As<HostnameRedirectsSettings>();
+        }
+    }
+
+}

--- a/HostnameRedirects/Services/IHostRedirectService.cs
+++ b/HostnameRedirects/Services/IHostRedirectService.cs
@@ -1,0 +1,8 @@
+﻿using Moov2.OrchardCore.SEO.HostnameRedirects.Models;
+using System.Threading.Tasks;
+
+namespace Moov2.OrchardCore.SEO.HostnameRedirects.Services {
+    public interface IHostRedirectService {
+        Task<HostnameRedirectsSettings> GetSettingsAsync();
+    }
+}

--- a/HostnameRedirects/Services/IRewriteOptionsService.cs
+++ b/HostnameRedirects/Services/IRewriteOptionsService.cs
@@ -1,0 +1,4 @@
+﻿namespace Moov2.OrchardCore.SEO.HostnameRedirects.Services {
+    public interface IRewriteOptionsSevice {
+    }
+}

--- a/HostnameRedirects/Services/RewriteOptionsService.cs
+++ b/HostnameRedirects/Services/RewriteOptionsService.cs
@@ -24,7 +24,13 @@ namespace Moov2.OrchardCore.SEO.HostnameRedirects.Services {
 
         #endregion
 
+        #region Properties
+
         public int StatusCode { get; } = (int) HttpStatusCode.MovedPermanently;
+
+        #endregion
+
+        #region Implementation
 
         public void ApplyRule(RewriteContext context) {
             var hostnameRedirectsSettings = _hostRedirectService.GetSettingsAsync().GetAwaiter().GetResult();
@@ -51,6 +57,8 @@ namespace Moov2.OrchardCore.SEO.HostnameRedirects.Services {
                 return;
             }
         }
+
+        #endregion
 
         #region Helpers
 

--- a/HostnameRedirects/Services/RewriteOptionsService.cs
+++ b/HostnameRedirects/Services/RewriteOptionsService.cs
@@ -56,9 +56,8 @@ namespace Moov2.OrchardCore.SEO.HostnameRedirects.Services {
 
         private string GetURL(RewriteContext context) {
             var request = context.HttpContext.Request;
-            var url = request.Scheme + "://" + request.Host.Value + request.PathBase + request.Path + request.QueryString;
 
-            return url;
+            return $"{request.Scheme}://{request.Host.Value}{request.PathBase}{request.Path}{request.QueryString}";
         }
 
         private bool CheckIfIgnored(HostnameRedirectsSettings settings, string url) {

--- a/HostnameRedirects/Services/RewriteOptionsService.cs
+++ b/HostnameRedirects/Services/RewriteOptionsService.cs
@@ -65,7 +65,7 @@ namespace Moov2.OrchardCore.SEO.HostnameRedirects.Services {
                 return false;
             }
 
-            return settings.IgnoredUrls.Split(new string[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).Any(x => url.StartsWith(x));
+            return settings.IgnoredUrls.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).Any(x => url.StartsWith(x));
         }
 
         private Uri ValidateWWW(HostnameRedirectsSettings settings, Uri url) {

--- a/HostnameRedirects/Services/RewriteOptionsService.cs
+++ b/HostnameRedirects/Services/RewriteOptionsService.cs
@@ -1,0 +1,138 @@
+﻿using Castle.Core.Logging;
+using Microsoft.AspNetCore.Rewrite;
+using Microsoft.Net.Http.Headers;
+using Moov2.OrchardCore.SEO.HostnameRedirects.Models;
+using System;
+using System.Linq;
+using System.Net;
+
+namespace Moov2.OrchardCore.SEO.HostnameRedirects.Services {
+    public class RewriteOptionsService : IRewriteOptionsSevice, IRule {
+
+        #region Dependencies
+
+        private readonly IHostRedirectService _hostRedirectService;
+
+        #endregion
+
+        #region Constructor
+
+        public RewriteOptionsService(IHostRedirectService hostRedirectService) {
+            _hostRedirectService = hostRedirectService;
+        }
+
+        #endregion
+
+        public int StatusCode { get; } = (int) HttpStatusCode.MovedPermanently;
+        public ILogger Logger { get; set; } = new NullLogger();
+
+        public void ApplyRule(RewriteContext context) {
+            var hostnameRedirectsSettings = _hostRedirectService.GetSettingsAsync().GetAwaiter().GetResult();
+
+            var url = getURL(context);
+
+            if (CheckIfIgnored(hostnameRedirectsSettings, url)) {
+                context.Result = RuleResult.ContinueRules;
+                return;
+            }
+
+            var consistentRequest = new Uri(url);
+            consistentRequest = ValidateWWW(hostnameRedirectsSettings, consistentRequest);
+            consistentRequest = ValidateNonWWW(hostnameRedirectsSettings, consistentRequest);
+            consistentRequest = ValidateSSL(hostnameRedirectsSettings, consistentRequest);
+            consistentRequest = ValidateRedirectToSiteUrl(hostnameRedirectsSettings, consistentRequest);
+
+
+            if (!consistentRequest.ToString().Equals(url)) {
+                var response = context.HttpContext.Response;
+                response.StatusCode = StatusCode;
+                response.Headers[HeaderNames.Location] = consistentRequest.ToString();
+                context.Result = RuleResult.EndResponse;
+                return;
+            }
+        }
+
+        #region Helpers
+
+        private string getURL(RewriteContext context) {
+            var request = context.HttpContext.Request;
+            var url = request.Scheme + "://" + request.Host.Value + request.PathBase + request.Path + request.QueryString;
+
+            return url;
+        }
+
+        private bool CheckIfIgnored(HostnameRedirectsSettings settings, string url) {
+            if (string.IsNullOrWhiteSpace(settings.IgnoredUrls)) {
+                return false;
+            }
+
+
+            var ignoredUrls = settings.IgnoredUrls.Split(new string[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
+
+            return settings.IgnoredUrls.Split(new string[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).Any(x => url.StartsWith(x));
+        }
+
+        private Uri ValidateWWW(HostnameRedirectsSettings settings, Uri url) {
+            if (settings.Redirect != HostnameRedirectModes.NonWWW) {
+                return url;
+            }
+
+            if (url.Authority.StartsWith("www.", StringComparison.OrdinalIgnoreCase)) {
+                return new Uri(url.ToString().Replace("www.", ""));
+            }
+
+            return url;
+        }
+
+        private Uri ValidateNonWWW(HostnameRedirectsSettings settings, Uri url) {
+            if (settings.Redirect != HostnameRedirectModes.WWW) {
+                return url;
+            }
+
+            if (!url.Authority.StartsWith("www.", StringComparison.OrdinalIgnoreCase)) {
+                return new Uri(url.ToString().Replace(string.Format("{0}://", url.Scheme), string.Format("{0}://www.", url.Scheme)));
+            }
+
+            return url;
+        }
+
+        private Uri ValidateSSL(HostnameRedirectsSettings settings, Uri url) {
+            if (!settings.ForceSSL) {
+                return url;
+            }
+
+            if (url.ToString().StartsWith("http://", StringComparison.OrdinalIgnoreCase)) {
+                return new Uri(url.ToString().Replace("http://", "https://"));
+            }
+
+            return url;
+        }
+
+        private Uri ValidateRedirectToSiteUrl(HostnameRedirectsSettings settings, Uri uri) {
+            if (settings.Redirect != HostnameRedirectModes.Domain || string.IsNullOrWhiteSpace(settings.RedirectToSiteUrl)) {
+                return uri;
+            }
+
+            Uri requestedUri;
+
+            try {
+                requestedUri = new Uri(settings.RedirectToSiteUrl);
+            } catch (Exception e) {
+                Logger.Error(string.Format("{0}, Error parsing RedirectToSiteURL, skipping redirect", e));
+                return uri;
+            }
+
+            if (requestedUri.Host == null || requestedUri.Host.Equals(uri.Host, StringComparison.OrdinalIgnoreCase)) {
+                return uri;
+            }
+
+            var builder = new UriBuilder(uri);
+            builder.Host = requestedUri.Host;
+            return builder.Uri;
+        }
+
+
+
+        #endregion
+    }
+}

--- a/HostnameRedirects/Services/RewriteOptionsService.cs
+++ b/HostnameRedirects/Services/RewriteOptionsService.cs
@@ -54,7 +54,7 @@ namespace Moov2.OrchardCore.SEO.HostnameRedirects.Services {
 
         #region Helpers
 
-        private string getURL(RewriteContext context) {
+        private string GetURL(RewriteContext context) {
             var request = context.HttpContext.Request;
             var url = request.Scheme + "://" + request.Host.Value + request.PathBase + request.Path + request.QueryString;
 

--- a/HostnameRedirects/Services/RewriteOptionsService.cs
+++ b/HostnameRedirects/Services/RewriteOptionsService.cs
@@ -29,7 +29,7 @@ namespace Moov2.OrchardCore.SEO.HostnameRedirects.Services {
         public void ApplyRule(RewriteContext context) {
             var hostnameRedirectsSettings = _hostRedirectService.GetSettingsAsync().GetAwaiter().GetResult();
 
-            var url = getURL(context);
+            var url = GetURL(context);
 
             if (CheckIfIgnored(hostnameRedirectsSettings, url)) {
                 context.Result = RuleResult.ContinueRules;

--- a/HostnameRedirects/Services/RewriteOptionsService.cs
+++ b/HostnameRedirects/Services/RewriteOptionsService.cs
@@ -12,6 +12,7 @@ namespace Moov2.OrchardCore.SEO.HostnameRedirects.Services {
         #region Dependencies
 
         private readonly IHostRedirectService _hostRedirectService;
+        public ILogger Logger { get; set; } = new NullLogger();
 
         #endregion
 
@@ -24,7 +25,6 @@ namespace Moov2.OrchardCore.SEO.HostnameRedirects.Services {
         #endregion
 
         public int StatusCode { get; } = (int) HttpStatusCode.MovedPermanently;
-        public ILogger Logger { get; set; } = new NullLogger();
 
         public void ApplyRule(RewriteContext context) {
             var hostnameRedirectsSettings = _hostRedirectService.GetSettingsAsync().GetAwaiter().GetResult();

--- a/HostnameRedirects/Services/RewriteOptionsService.cs
+++ b/HostnameRedirects/Services/RewriteOptionsService.cs
@@ -65,9 +65,6 @@ namespace Moov2.OrchardCore.SEO.HostnameRedirects.Services {
                 return false;
             }
 
-
-            var ignoredUrls = settings.IgnoredUrls.Split(new string[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
-
             return settings.IgnoredUrls.Split(new string[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).Any(x => url.StartsWith(x));
         }
 

--- a/HostnameRedirects/Startup.cs
+++ b/HostnameRedirects/Startup.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Moov2.OrchardCore.SEO.HostnameRedirects.Drivers;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.Modules;
+using OrchardCore.Navigation;
+using OrchardCore.Security.Permissions;
+using OrchardCore.Settings;
+using System;
+
+namespace Moov2.OrchardCore.SEO.HostnameRedirects
+{
+    [Feature("Moov2.OrchardCore.SEO.HostnameRedirects")]
+    public class Startup : StartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddScoped<INavigationProvider, AdminMenu>();
+            services.AddScoped<IDisplayDriver<ISite>, HostnameRedirectsSettingsDisplayDriver>();
+            services.AddScoped<IPermissionProvider, Permissions>();
+        }
+
+        public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)
+        {
+
+        }
+    }
+}

--- a/HostnameRedirects/Startup.cs
+++ b/HostnameRedirects/Startup.cs
@@ -1,7 +1,10 @@
 ﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Rewrite;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moov2.OrchardCore.SEO.HostnameRedirects.Drivers;
+using Moov2.OrchardCore.SEO.HostnameRedirects.Services;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
@@ -9,20 +12,27 @@ using OrchardCore.Security.Permissions;
 using OrchardCore.Settings;
 using System;
 
-namespace Moov2.OrchardCore.SEO.HostnameRedirects
-{
+namespace Moov2.OrchardCore.SEO.HostnameRedirects {
     [Feature("Moov2.OrchardCore.SEO.HostnameRedirects")]
     public class Startup : StartupBase
     {
-        public override void ConfigureServices(IServiceCollection services)
-        {
+        public override void ConfigureServices(IServiceCollection services) {
             services.AddScoped<INavigationProvider, AdminMenu>();
             services.AddScoped<IDisplayDriver<ISite>, HostnameRedirectsSettingsDisplayDriver>();
             services.AddScoped<IPermissionProvider, Permissions>();
+
+            services.AddSingleton<IHostRedirectService, HostRedirectService>();
+            services.AddSingleton<IRewriteOptionsSevice, RewriteOptionsService>();
+
         }
 
-        public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)
-        {
+        public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider) {
+            var rewriteOptionsService = app.ApplicationServices.GetService<IRewriteOptionsSevice>();
+
+            var rewriteOptions = new RewriteOptions();
+            rewriteOptions.Add((IRule)rewriteOptionsService);
+
+            app.UseRewriter(rewriteOptions);
 
         }
     }

--- a/HostnameRedirects/ViewModels/HostnameRedirectsSettingsViewModel.cs
+++ b/HostnameRedirects/ViewModels/HostnameRedirectsSettingsViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Moov2.OrchardCore.SEO.HostnameRedirects.ViewModels
+{
+    public class HostnameRedirectsSettingsViewModel
+    {
+        public int Mode { get; set; }
+    }
+}

--- a/HostnameRedirects/ViewModels/HostnameRedirectsSettingsViewModel.cs
+++ b/HostnameRedirects/ViewModels/HostnameRedirectsSettingsViewModel.cs
@@ -2,6 +2,9 @@
 {
     public class HostnameRedirectsSettingsViewModel
     {
-        public int Mode { get; set; }
+        public int Redirect { get; set; }
+        public string RedirectToSiteUrl { get; set; }
+        public bool ForceSSL { get; set; }
+        public string IgnoredUrls { get; set; }
     }
 }

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -24,3 +24,11 @@ using OrchardCore.Modules.Manifest;
     Description = "Manage contents of robots.txt.",
     Category = "Content"
 )]
+
+
+[assembly: Feature(
+    Id = "Moov2.OrchardCore.SEO.HostnameRedirects",
+    Name = "Hostname Redirects",
+    Description = "Manage hostname redirects.",
+    Category = "Content"
+)]

--- a/Moov2.OrchardCore.SEO.csproj
+++ b/Moov2.OrchardCore.SEO.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Rewrite" Version="2.2.0-preview3-35497" />
     <PackageReference Include="OrchardCore.Admin" Version="1.0.0-beta3-69192" />
     <PackageReference Include="OrchardCore.Autoroute" Version="1.0.0-beta3-69192" />
     <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-beta3-69192" />

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Module for [Orchard Core](https://github.com/OrchardCMS/OrchardCore) that provid
 
 Create redirect content items that'll redirect a relative URL to another URL.
 
+### Hostname redirects
+
+Define main hostname to redirect all domain variations and force SSL.
+
 ### Robots.txt
 
 Manage contents of `/robots.txt`.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Module for [Orchard Core](https://github.com/OrchardCMS/OrchardCore) that provid
 
 ## Features
 
-### Redirects
-
-Create redirect content items that'll redirect a relative URL to another URL.
-
 ### Hostname redirects
 
 Define main hostname to redirect all domain variations and force SSL.
+
+### Redirects
+
+Create redirect content items that'll redirect a relative URL to another URL.
 
 ### Robots.txt
 

--- a/Views/HostnameRedirectsSettings.Edit.cshtml
+++ b/Views/HostnameRedirectsSettings.Edit.cshtml
@@ -1,0 +1,35 @@
+﻿@model Moov2.OrchardCore.SEO.HostnameRedirects.ViewModels.HostnameRedirectsSettingsViewModel
+
+@using Moov2.OrchardCore.SEO.HostnameRedirects.Models
+
+<fieldset class="form-group">
+    <label asp-for="Redirect">@T["Redirect"]</label>
+    <select asp-for="Redirect" class="form-control content-preview-select">
+        <option value="@HostnameRedirectModes.None">@T["No Redirect"]</option>
+        <option value="@HostnameRedirectModes.NonWWW">@T["Redirect to none WWW"]</option>
+        <option value="@HostnameRedirectModes.WWW">@T["Redirect to WWW"]</option>
+        <option value="@HostnameRedirectModes.Domain">@T["Redirect to Domain"]</option>
+    </select>
+    <span class="hint">@T["Redirect to none WWW: Visitors making a request to the site using \"www\" will be redirected with a 301 response to the same URL without www."]</span><br/>
+    <span class="hint">@T["Redirect to WWW: Visitors making a request to the site not using \"www\" will be redirected with a 301 response to the same URL with www."]</span><br/>
+    <span class="hint">@T["Redirect to Domain: Visitors making a request to the site not using the configured domain will be redirected with a 301 response to the domain."]</span><br/>
+</fieldset>
+
+<fieldset class="form-group" asp-validation-class-for="RedirectToSiteUrl">
+    <label asp-for="RedirectToSiteUrl">@T["Redirect to Domain"] <span asp-validation-for="RedirectToSiteUrl"></span></label>
+    <input asp-for="RedirectToSiteUrl" class="form-control content-preview-text content-caption-text" placeholder="E.g. https://domain.example.com" />
+</fieldset>
+
+<fieldset class="form-group" asp-validation-class-for="ForceSSL">
+    <div class="custom-control custom-checkbox">
+        <input asp-for="ForceSSL" type="checkbox" class="custom-control-input">
+        <label class="custom-control-label" asp-for="ForceSSL">@T["Force SSL"]</label>
+        <span class="hint">@T["Force visitors to use SSL (https). This is a basic implementation that will change the URL from http to https."]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group" asp-validation-class-for="IgnoredUrls">
+    <label asp-for="IgnoredUrls">@T["Ignored URLs"] <span asp-validation-for="IgnoredUrls"></span></label>
+    <textarea asp-for="IgnoredUrls" rows="5" class="form-control content-preview-text"></textarea>
+    <span class="hint">@T["URLs that should be ignored by the redirect settings (ideal for handling staging slots within Azure). Use a new line to seperate each URL."]</span>
+</fieldset>

--- a/Views/HostnameRedirectsSettings.Edit.cshtml
+++ b/Views/HostnameRedirectsSettings.Edit.cshtml
@@ -2,6 +2,17 @@
 
 @using Moov2.OrchardCore.SEO.HostnameRedirects.Models
 
+
+<fieldset class="form-group" asp-validation-class-for="ForceSSL">
+    <div class="custom-control custom-checkbox">
+        <input asp-for="ForceSSL" type="checkbox" class="custom-control-input">
+        <label class="custom-control-label" asp-for="ForceSSL">@T["Force SSL"]</label><br/>
+        <span class="hint">@T["Force visitors to use SSL (https). This is a basic implementation that will change the URL from http to https."]</span>
+    </div>
+</fieldset>
+
+<hr />
+
 <fieldset class="form-group">
     <label asp-for="Redirect">@T["Redirect"]</label>
     <select asp-for="Redirect" class="form-control content-preview-select js-redirect-select">
@@ -10,23 +21,17 @@
         <option value="@HostnameRedirectModes.WWW">@T["Redirect to WWW"]</option>
         <option value="@HostnameRedirectModes.Domain">@T["Redirect to Domain"]</option>
     </select>
-    <span class="hint">@T["Redirect to none WWW: Visitors making a request to the site using \"www\" will be redirected with a 301 response to the same URL without www."]</span><br/>
-    <span class="hint">@T["Redirect to WWW: Visitors making a request to the site not using \"www\" will be redirected with a 301 response to the same URL with www."]</span><br/>
-    <span class="hint">@T["Redirect to Domain: Visitors making a request to the site not using the configured domain will be redirected with a 301 response to the domain."]</span><br/>
+    <span class="hint">@T["Redirect to none WWW: Visitors making a request to the site using \"www\" will be redirected with a 301 response to the same URL without www."]</span><br />
+    <span class="hint">@T["Redirect to WWW: Visitors making a request to the site not using \"www\" will be redirected with a 301 response to the same URL with www."]</span><br />
+    <span class="hint">@T["Redirect to Domain: Visitors making a request to the site not using the configured domain will be redirected with a 301 response to the domain."]</span><br />
 </fieldset>
 
-<fieldset class="form-group js-redirect-to-site-field" asp-validation-class-for="RedirectToSiteUrl">
+<fieldset class="form-group js-redirect-to-site-field" asp-validation-class-for="RedirectToSiteUrl" style="display: none;">
     <label asp-for="RedirectToSiteUrl">@T["Redirect to Domain"] <span asp-validation-for="RedirectToSiteUrl"></span></label>
     <input asp-for="RedirectToSiteUrl" class="form-control content-preview-text content-caption-text" placeholder="E.g. https://domain.example.com" />
 </fieldset>
 
-<fieldset class="form-group" asp-validation-class-for="ForceSSL" style="display: none;">
-    <div class="custom-control custom-checkbox">
-        <input asp-for="ForceSSL" type="checkbox" class="custom-control-input">
-        <label class="custom-control-label" asp-for="ForceSSL">@T["Force SSL"]</label>
-        <span class="hint">@T["Force visitors to use SSL (https). This is a basic implementation that will change the URL from http to https."]</span>
-    </div>
-</fieldset>
+<hr />
 
 <fieldset class="form-group" asp-validation-class-for="IgnoredUrls">
     <label asp-for="IgnoredUrls">@T["Ignored URLs"] <span asp-validation-for="IgnoredUrls"></span></label>

--- a/Views/HostnameRedirectsSettings.Edit.cshtml
+++ b/Views/HostnameRedirectsSettings.Edit.cshtml
@@ -4,7 +4,7 @@
 
 <fieldset class="form-group">
     <label asp-for="Redirect">@T["Redirect"]</label>
-    <select asp-for="Redirect" class="form-control content-preview-select">
+    <select asp-for="Redirect" class="form-control content-preview-select js-redirect-select">
         <option value="@HostnameRedirectModes.None">@T["No Redirect"]</option>
         <option value="@HostnameRedirectModes.NonWWW">@T["Redirect to none WWW"]</option>
         <option value="@HostnameRedirectModes.WWW">@T["Redirect to WWW"]</option>
@@ -15,12 +15,12 @@
     <span class="hint">@T["Redirect to Domain: Visitors making a request to the site not using the configured domain will be redirected with a 301 response to the domain."]</span><br/>
 </fieldset>
 
-<fieldset class="form-group" asp-validation-class-for="RedirectToSiteUrl">
+<fieldset class="form-group js-redirect-to-site-field" asp-validation-class-for="RedirectToSiteUrl">
     <label asp-for="RedirectToSiteUrl">@T["Redirect to Domain"] <span asp-validation-for="RedirectToSiteUrl"></span></label>
     <input asp-for="RedirectToSiteUrl" class="form-control content-preview-text content-caption-text" placeholder="E.g. https://domain.example.com" />
 </fieldset>
 
-<fieldset class="form-group" asp-validation-class-for="ForceSSL">
+<fieldset class="form-group" asp-validation-class-for="ForceSSL" style="display: none;">
     <div class="custom-control custom-checkbox">
         <input asp-for="ForceSSL" type="checkbox" class="custom-control-input">
         <label class="custom-control-label" asp-for="ForceSSL">@T["Force SSL"]</label>
@@ -33,3 +33,27 @@
     <textarea asp-for="IgnoredUrls" rows="5" class="form-control content-preview-text"></textarea>
     <span class="hint">@T["URLs that should be ignored by the redirect settings (ideal for handling staging slots within Azure). Use a new line to seperate each URL."]</span>
 </fieldset>
+
+<script type="text/javascript">
+    document.onreadystatechange = function () {
+        if (document.readyState != "interactive") {
+            return;
+        }
+
+        var $redirectToSiteField = document.querySelector('.js-redirect-to-site-field');
+        var $redirectSelect = document.querySelector('.js-redirect-select');
+
+        var setCustomContentFieldVisibility = function () {
+            if ($redirectSelect.value === "@HostnameRedirectModes.Domain") {
+                $redirectToSiteField.style.display = 'block';
+                return;
+            }
+
+            $redirectToSiteField.style.display = 'none';
+        };
+
+        $redirectSelect.addEventListener('change', setCustomContentFieldVisibility);
+
+        setCustomContentFieldVisibility();
+    };
+</script>


### PR DESCRIPTION
Using hostname redirect module allows users to:
- Force SSL (Force visitors to use SSL (https). This is a basic implementation that will change the URL from http to https.)
- Redirect to none WWW, to WWW or a custom domain