### PR TITLE
Add missing dependency to OrchardCore.Data.Abstractions

### DIFF
--- a/Moov2.OrchardCore.SEO.csproj
+++ b/Moov2.OrchardCore.SEO.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="OrchardCore.Autoroute" Version="1.0.0-beta3-*" />
     <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-beta3-*" />
     <PackageReference Include="OrchardCore.ContentManagement.Display" Version="1.0.0-beta3-*" />
+    <PackageReference Include="OrchardCore.Data.Abstractions" Version="1.0.0-beta3-*" />
     <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-beta3-*" />
     <PackageReference Include="OrchardCore.Navigation.Core" Version="1.0.0-beta3-*" />
   </ItemGroup>


### PR DESCRIPTION
Currently there is an issue running the migrations in the 301 redirects module due to a missing dependency (YesSql.Sql.SchemaBuilder). The migrations contain a reference to `OrchardCore.Data`, however the project doesn't include it's own reference to `OrchardCore.Data`.

Attempt to solve #3.