### PR TITLE
Add Azure Pipelines build scripts

### DIFF
--- a/azure-pipelines-prerelease.yml
+++ b/azure-pipelines-prerelease.yml
@@ -1,0 +1,29 @@
+pool:
+  name: Hosted VS2017
+variables:
+  BuildConfiguration: 'Release'
+
+steps:
+- task: tmarkovski.projectversionasvariable.versionintovariable.projectversionasvariable@1
+  displayName: 'Get Project Version as variables from Etch.OrchardCore.SEO.csproj'
+  inputs:
+    path: Etch.OrchardCore.SEO.csproj
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet build'
+  inputs:
+    arguments: '-c $(BuildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet pack'
+  inputs:
+    command: pack
+    versioningScheme: byPrereleaseNumber
+    majorVersion: '$(Version.Major)'
+    minorVersion: '$(Version.Minor)'
+    patchVersion: '$(Version.Patch)'
+
+- task: PublishPipelineArtifact@0
+  displayName: 'Publish Pipeline Artifact'
+  inputs:
+    targetPath: '$(Build.ArtifactStagingDirectory)'

--- a/azure-pipelines-stable.yml
+++ b/azure-pipelines-stable.yml
@@ -3,6 +3,9 @@ pool:
 variables:
   BuildConfiguration: 'Release'
 
+trigger: none
+pr: none
+
 steps:
 - task: tmarkovski.projectversionasvariable.versionintovariable.projectversionasvariable@1
   displayName: 'Get Project Version as variables from Etch.OrchardCore.SEO.csproj'

--- a/azure-pipelines-stable.yml
+++ b/azure-pipelines-stable.yml
@@ -1,0 +1,27 @@
+pool:
+  name: Hosted VS2017
+variables:
+  BuildConfiguration: 'Release'
+
+steps:
+- task: tmarkovski.projectversionasvariable.versionintovariable.projectversionasvariable@1
+  displayName: 'Get Project Version as variables from Etch.OrchardCore.SEO.csproj'
+  inputs:
+    path: Etch.OrchardCore.SEO.csproj
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet build'
+  inputs:
+    arguments: '-c $(BuildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet pack'
+  inputs:
+    command: pack
+    versioningScheme: byEnvVar
+    versionEnvVar: 'VERSION_MAJORMINORPATCH'
+
+- task: PublishPipelineArtifact@0
+  displayName: 'Publish Pipeline Artifact'
+  inputs:
+    targetPath: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
Added build scripts for working with Azure DevOps Pipeline builds.

The `azure-pipelines-prerelease.yml` will build a package with a prerelease suffix of CI and the current date/time. This allows continuous integration for easy testing and development of packages along side a site which uses them. The version number itself is based on the assembly version number.

The `azure-pipelines-release` build is exactly the same except it simply uses the assembly's 
 `major.minor.patch` to create a stable version for the current version number for deployment to a Nuget feed.