### PR TITLE
Fix Razor Precompilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: csharp
 mono: none
-dotnet: 2.0.0
+dist: bionic
+dotnet: 2.2.100
 
 install:
 - dotnet restore

--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -14,7 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Rewrite" Version="2.2.0-preview3-35497" />
     <PackageReference Include="OrchardCore.Admin" Version="1.0.0-beta3-71077" />
     <PackageReference Include="OrchardCore.Autoroute" Version="1.0.0-beta3-71077" />
     <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-beta3-71077" />
@@ -25,7 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Rewrite" Version="2.2.0-preview3-35497" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Replicate the csproj in the official [Orchard Core templates](https://github.com/OrchardCMS/OrchardCore/blob/dev/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/OrchardCore.Templates.Cms.Module.csproj). Changes were to change the SDK to use Razor and add reference to `Microsoft.AspNetCore.Mvc`.

Also had to update travis to use dotnet 2.2.x.