### PR TITLE
Manage Trailing Slashes Strategy

### DIFF
--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.4.0-beta</Version>
+    <Version>0.4.1-beta</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>

--- a/HostnameRedirects/Drivers/HostnameRedirectsSettingsDisplayDriver.cs
+++ b/HostnameRedirects/Drivers/HostnameRedirectsSettingsDisplayDriver.cs
@@ -52,6 +52,7 @@ namespace Etch.OrchardCore.SEO.HostnameRedirects.Drivers
                 model.ForceSSL = settings.ForceSSL;
                 model.RedirectToSiteUrl = settings.RedirectToSiteUrl;
                 model.IgnoredUrls = settings.IgnoredUrls;
+                model.TrailingSlashes = settings.TrailingSlashes;
             }).Location("Content:3").OnGroup(GroupId);
         }
 
@@ -74,6 +75,7 @@ namespace Etch.OrchardCore.SEO.HostnameRedirects.Drivers
                 settings.ForceSSL = model.ForceSSL;
                 settings.RedirectToSiteUrl = model.RedirectToSiteUrl;
                 settings.IgnoredUrls = model.IgnoredUrls;
+                settings.TrailingSlashes = model.TrailingSlashes;
             }
 
             return await EditAsync(settings, context);

--- a/HostnameRedirects/Models/HostnameRedirectsSettings.cs
+++ b/HostnameRedirects/Models/HostnameRedirectsSettings.cs
@@ -6,5 +6,7 @@
         public string RedirectToSiteUrl { get; set; }
         public bool ForceSSL { get; set; }
         public string IgnoredUrls { get; set; }
+
+        public int TrailingSlashes { get; set; }
     }
 }

--- a/HostnameRedirects/Models/TrailingSlashesModes.cs
+++ b/HostnameRedirects/Models/TrailingSlashesModes.cs
@@ -1,0 +1,9 @@
+﻿namespace Etch.OrchardCore.SEO.HostnameRedirects.Models
+{
+    public class TrailingSlashesModes
+    {
+        public const int None = 0;
+        public const int Remove = 1;
+        public const int Append = 2;
+    }
+}

--- a/HostnameRedirects/ViewModels/HostnameRedirectsSettingsViewModel.cs
+++ b/HostnameRedirects/ViewModels/HostnameRedirectsSettingsViewModel.cs
@@ -6,5 +6,6 @@
         public string RedirectToSiteUrl { get; set; }
         public bool ForceSSL { get; set; }
         public string IgnoredUrls { get; set; }
+        public int TrailingSlashes { get; set; }
     }
 }

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "SEO",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "0.4.0"
+    Version = "0.4.1"
 )]
 
 [assembly: Feature(

--- a/Views/HostnameRedirectsSettings.Edit.cshtml
+++ b/Views/HostnameRedirectsSettings.Edit.cshtml
@@ -6,7 +6,7 @@
 <fieldset class="form-group" asp-validation-class-for="ForceSSL">
     <div class="custom-control custom-checkbox">
         <input asp-for="ForceSSL" type="checkbox" class="custom-control-input">
-        <label class="custom-control-label" asp-for="ForceSSL">@T["Force SSL"]</label><br/>
+        <label class="custom-control-label" asp-for="ForceSSL">@T["Force SSL"]</label><br />
         <span class="hint">@T["Force visitors to use SSL (https). This is a basic implementation that will change the URL from http to https."]</span>
     </div>
 </fieldset>
@@ -29,6 +29,17 @@
 <fieldset class="form-group js-redirect-to-site-field" asp-validation-class-for="RedirectToSiteUrl" style="display: none;">
     <label asp-for="RedirectToSiteUrl">@T["Redirect to Domain"] <span asp-validation-for="RedirectToSiteUrl"></span></label>
     <input asp-for="RedirectToSiteUrl" class="form-control content-preview-text content-caption-text" placeholder="E.g. https://domain.example.com" />
+</fieldset>
+
+<hr />
+
+<fieldset class="form-group">
+    <label asp-for="TrailingSlashes">@T["Trailing Slashes"]</label>
+    <select asp-for="TrailingSlashes" class="form-control content-preview-select">
+        <option value="@TrailingSlashesModes.None">@T["Ignore"]</option>
+        <option value="@TrailingSlashesModes.Remove">@T["Remove Trailing Slash"]</option>
+        <option value="@TrailingSlashesModes.Append">@T["Append Trailing Slash"]</option>
+    </select>
 </fieldset>
 
 <hr />


### PR DESCRIPTION
Added the ability to control consistent URLs with regards to trailing slashes. Within the hostname redirect settings the admin can choose to ignore, append or remove trailing slashes.

There is an issue (#6) where this is discussed but this update doesn't cater for all the things an admin may want to control.