### PR TITLE
Fix appending slashes on static files handled by controller

### DIFF
--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.4.1-beta</Version>
+    <Version>0.4.2-beta</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>

--- a/HostnameRedirects/Services/RewriteOptionsService.cs
+++ b/HostnameRedirects/Services/RewriteOptionsService.cs
@@ -77,6 +77,11 @@ namespace Etch.OrchardCore.SEO.HostnameRedirects.Services {
             return settings.IgnoredUrls.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).Any(x => url.StartsWith(x));
         }
 
+        private bool IsStaticFile(string path)
+        {
+            return path.Contains(".");
+        }
+
         private Uri ValidateWWW(HostnameRedirectsSettings settings, Uri url) {
             if (settings.Redirect != HostnameRedirectModes.NonWWW) {
                 return url;
@@ -146,7 +151,7 @@ namespace Etch.OrchardCore.SEO.HostnameRedirects.Services {
             var lastSegment = uri.Segments.Last();
 
             // ignore as request is for homepage.
-            if (lastSegment == "/")
+            if (lastSegment == "/" || IsStaticFile(lastSegment))
             {
                 return uri;
             }


### PR DESCRIPTION
No longer append/remove trailing slashes when request is for a static file (e.g. robots.txt).