### PR TITLE
Fix incorrect URLs to images in meta tags when using CDN

### DIFF
--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.4.2-beta</Version>
+    <Version>0.4.3-beta</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "SEO",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "0.4.1"
+    Version = "0.4.3"
 )]
 
 [assembly: Feature(

--- a/MetaTags/Services/MetaTagsService.cs
+++ b/MetaTags/Services/MetaTagsService.cs
@@ -59,7 +59,7 @@ namespace Etch.OrchardCore.SEO.MetaTags.Services
 
             if (metaTags.Images != null && metaTags.Images.Any())
             {
-                _resourceManager.RegisterMeta(new MetaEntry { Name = "og:image", Content = $"{GetHostUrl()}{_mediaFileStore.MapPathToPublicUrl(metaTags.Images[0])}" });
+                _resourceManager.RegisterMeta(new MetaEntry { Name = "og:image", Content = GetMediaUrl(metaTags.Images[0]) });
             }
         }
 
@@ -80,7 +80,7 @@ namespace Etch.OrchardCore.SEO.MetaTags.Services
 
             if (metaTags.Images != null && metaTags.Images.Any())
             {
-                _resourceManager.RegisterMeta(new MetaEntry { Name = "twitter:image", Content = $"{GetHostUrl()}{_mediaFileStore.MapPathToPublicUrl(metaTags.Images[0])}" });
+                _resourceManager.RegisterMeta(new MetaEntry { Name = "twitter:image", Content = GetMediaUrl(metaTags.Images[0]) });
             }
         }
 
@@ -92,6 +92,12 @@ namespace Etch.OrchardCore.SEO.MetaTags.Services
         {
             var request = _httpContextAccessor.HttpContext.Request;
             return $"{request.Scheme}://{request.Host}";
+        }
+
+        public string GetMediaUrl(string path)
+        {
+            var imageUrl = _mediaFileStore.MapPathToPublicUrl(path);
+            return imageUrl.StartsWith("http") ? imageUrl : $"{GetHostUrl()}{imageUrl}";
         }
 
         private string GetPageUrl()


### PR DESCRIPTION
Issue here was the host URL was being prepended to the image URL, which
was pointed at the CDN host. The host URL should only be prepended when
the image URL is relative.

Bump to 0.4.3.