### PR TITLE
Hostname Redirects: Ignore /admin and fix infinite redirects

### DIFF
--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.4.3-beta</Version>
+    <Version>0.4.4-beta</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>

--- a/HostnameRedirects/Services/RewriteOptionsService.cs
+++ b/HostnameRedirects/Services/RewriteOptionsService.cs
@@ -72,6 +72,11 @@ namespace Etch.OrchardCore.SEO.HostnameRedirects.Services {
         }
 
         private bool CheckIfIgnored(HostnameRedirectsSettings settings, string url) {
+            if(IsAdmin(url))
+            {
+                return true;
+            }
+
             if (string.IsNullOrWhiteSpace(settings.IgnoredUrls)) {
                 return false;
             }
@@ -79,8 +84,18 @@ namespace Etch.OrchardCore.SEO.HostnameRedirects.Services {
             return settings.IgnoredUrls.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).Any(x => url.StartsWith(x));
         }
 
-        private bool IsStaticFile(string path)
-        {
+        private bool IsAdmin(string url) {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                return false;
+            }
+
+            var lowerUrl = url.ToLower();
+
+            return lowerUrl.EndsWith("/admin") || lowerUrl.Contains("/admin/");
+        }
+
+        private bool IsStaticFile(string path) {
             return path.Contains(".");
         }
 
@@ -143,8 +158,7 @@ namespace Etch.OrchardCore.SEO.HostnameRedirects.Services {
             return builder.Uri;
         }
 
-        private Uri ValidateTrailingSlashes(HostnameRedirectsSettings settings, Uri uri)
-        {
+        private Uri ValidateTrailingSlashes(HostnameRedirectsSettings settings, Uri uri) {
             if (settings.TrailingSlashes == TrailingSlashesModes.None)
             {
                 return uri;

--- a/HostnameRedirects/Services/RewriteOptionsService.cs
+++ b/HostnameRedirects/Services/RewriteOptionsService.cs
@@ -50,10 +50,12 @@ namespace Etch.OrchardCore.SEO.HostnameRedirects.Services {
             consistentRequest = ValidateRedirectToSiteUrl(hostnameRedirectsSettings, consistentRequest);
             consistentRequest = ValidateTrailingSlashes(hostnameRedirectsSettings, consistentRequest);
 
-            if (!consistentRequest.ToString().Equals(url)) {
+            var consistentRequestUrl = WebUtility.UrlDecode(consistentRequest.ToString());
+
+            if (!consistentRequestUrl.Equals(url)) {
                 var response = context.HttpContext.Response;
                 response.StatusCode = StatusCode;
-                response.Headers[HeaderNames.Location] = consistentRequest.ToString();
+                response.Headers[HeaderNames.Location] = consistentRequestUrl;
                 context.Result = RuleResult.EndResponse;
                 return;
             }
@@ -66,7 +68,7 @@ namespace Etch.OrchardCore.SEO.HostnameRedirects.Services {
         private string GetURL(RewriteContext context) {
             var request = context.HttpContext.Request;
 
-            return $"{request.Scheme}://{request.Host.Value}{request.PathBase}{request.Path}{request.QueryString}";
+            return WebUtility.UrlDecode($"{request.Scheme}://{request.Host.Value}{request.PathBase}{request.Path}{request.QueryString}");
         }
 
         private bool CheckIfIgnored(HostnameRedirectsSettings settings, string url) {

--- a/HostnameRedirects/Services/RewriteOptionsService.cs
+++ b/HostnameRedirects/Services/RewriteOptionsService.cs
@@ -72,7 +72,7 @@ namespace Etch.OrchardCore.SEO.HostnameRedirects.Services {
         }
 
         private bool CheckIfIgnored(HostnameRedirectsSettings settings, string url) {
-            if(IsAdmin(url))
+            if (IsAdmin(url))
             {
                 return true;
             }

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "SEO",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "0.4.3"
+    Version = "0.4.4"
 )]
 
 [assembly: Feature(


### PR DESCRIPTION
Minor update to the hostname redirects feature to fix the issues listed below.

In `RewriteOptionsService` we now always ensure both our request URL and our rule process URL are run through `UrlDecode` before we compare them, this fixes the infinite redirect issue (#23, #21).

We also now check for the presence of `admin` as a URL segment per #20, but it should be noted that this doesn't cover modules that have chosen not to use the `AdminController` convention OR set a specific route template which contains `admin`.