### PR TITLE
Custom meta tags

### DIFF
--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.4.4-beta</Version>
+    <Version>0.4.5-beta</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>

--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Etch.OrchardCore.Fields" Version="0.6.1-beta" />
     <PackageReference Include="FluentExcel" Version="2.2.0" />
     <PackageReference Include="OrchardCore.Admin" Version="1.0.0-beta3-71077" />
     <PackageReference Include="OrchardCore.Autoroute" Version="1.0.0-beta3-71077" />

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -49,7 +49,8 @@ using OrchardCore.Modules.Manifest;
     Name = "Meta Tags",
     Dependencies = new[]
     {
-        "OrchardCore.Media"
+        "OrchardCore.Media",
+        "Etch.OrchardCore.Field.Dictionary"
     },
     Description = "Manage meta tags for content items.",
     Category = "Content"

--- a/MetaTags/Constants.cs
+++ b/MetaTags/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace Etch.OrchardCore.SEO.MetaTags
+{
+    public class Constants
+    {
+        public const string CustomFieldName = "Custom";
+    }
+}

--- a/MetaTags/Drivers/MetaTagsPartDisplay.cs
+++ b/MetaTags/Drivers/MetaTagsPartDisplay.cs
@@ -1,4 +1,5 @@
-﻿using Etch.OrchardCore.SEO.MetaTags.Models;
+﻿using Etch.OrchardCore.SEO.MetaTags.Extensions;
+using Etch.OrchardCore.SEO.MetaTags.Models;
 using Etch.OrchardCore.SEO.MetaTags.Services;
 using Etch.OrchardCore.SEO.MetaTags.ViewModels;
 using Newtonsoft.Json;
@@ -39,9 +40,12 @@ namespace Etch.OrchardCore.SEO.MetaTags.Drivers
                 return null;
             }
 
-            _metaTagsService.RegisterDefaults(metaTagsPart);
-            _metaTagsService.RegisterOpenGraph(metaTagsPart);
-            _metaTagsService.RegisterTwitter(metaTagsPart);
+            var customMetaTags = metaTagsPart.GetDictionaryFieldValue(Constants.CustomFieldName);
+
+            _metaTagsService.RegisterCustom(customMetaTags);
+            _metaTagsService.RegisterDefaults(metaTagsPart, customMetaTags);
+            _metaTagsService.RegisterOpenGraph(metaTagsPart, customMetaTags);
+            _metaTagsService.RegisterTwitter(metaTagsPart, customMetaTags);
 
             return Initialize<MetaTagsPartViewModel>("MetaTagsPart", model =>
             {

--- a/MetaTags/Extensions/DictionaryFieldExtensions.cs
+++ b/MetaTags/Extensions/DictionaryFieldExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Etch.OrchardCore.Fields.Dictionary.Fields;
+using Etch.OrchardCore.Fields.Dictionary.Models;
+using OrchardCore.ContentManagement;
+using System.Collections.Generic;
+
+namespace Etch.OrchardCore.SEO.MetaTags.Extensions
+{
+    public static class DictionaryFieldExtensions
+    {
+        public static IList<DictionaryItem> GetDictionaryFieldValue(this ContentPart part, string name)
+        {
+            return part?.Get<DictionaryField>(name)?.Data;
+        }
+    }
+}

--- a/MetaTags/Migrations.cs
+++ b/MetaTags/Migrations.cs
@@ -1,6 +1,7 @@
 ﻿using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Data.Migration;
+using Etch.OrchardCore.Fields.Dictionary.Fields;
 
 namespace Etch.OrchardCore.SEO.MetaTags
 {
@@ -20,6 +21,19 @@ namespace Etch.OrchardCore.SEO.MetaTags
                 .WithDescription("Provides meta tags for your content item."));
 
             return 1;
+        }
+
+        public int UpdateFrom1()
+        {
+
+            _contentDefinitionManager.AlterPartDefinition("MetaTagsPart", builder => builder
+                .WithField(Constants.CustomFieldName, field => field
+                    .OfType(typeof(DictionaryField).Name)
+                    .WithSetting("Hint", "Apply custom meta tags that will override the defaults applied through defining image, title & description.")
+                )
+            );
+
+            return 2;
         }
     }
 }

--- a/MetaTags/Services/IMetaTagsService.cs
+++ b/MetaTags/Services/IMetaTagsService.cs
@@ -1,11 +1,14 @@
-﻿using Etch.OrchardCore.SEO.MetaTags.Models;
+﻿using Etch.OrchardCore.Fields.Dictionary.Models;
+using Etch.OrchardCore.SEO.MetaTags.Models;
+using System.Collections.Generic;
 
 namespace Etch.OrchardCore.SEO.MetaTags.Services
 {
     public interface IMetaTagsService
     {
-        void RegisterDefaults(MetaTagsPart metaTags);
-        void RegisterOpenGraph(MetaTagsPart metaTags);
-        void RegisterTwitter(MetaTagsPart metaTags);
+        void RegisterDefaults(MetaTagsPart metaTags, IList<DictionaryItem> customMetaTags = null);
+        void RegisterOpenGraph(MetaTagsPart metaTags, IList<DictionaryItem> customMetaTags = null);
+        void RegisterTwitter(MetaTagsPart metaTags, IList<DictionaryItem> customMetaTags = null);
+        void RegisterCustom(IList<DictionaryItem> customMetaTags);
     }
 }

--- a/MetaTags/Services/MetaTagsService.cs
+++ b/MetaTags/Services/MetaTagsService.cs
@@ -3,6 +3,10 @@ using Etch.OrchardCore.SEO.MetaTags.Models;
 using OrchardCore.Media;
 using OrchardCore.ResourceManagement;
 using System.Linq;
+using Etch.OrchardCore.SEO.MetaTags.Extensions;
+using Etch.OrchardCore.Fields.Dictionary.Models;
+using System.Collections.Generic;
+using System;
 
 namespace Etch.OrchardCore.SEO.MetaTags.Services
 {
@@ -29,56 +33,83 @@ namespace Etch.OrchardCore.SEO.MetaTags.Services
 
         #region Implementation
 
-        public void RegisterDefaults(MetaTagsPart metaTags)
+        public void RegisterCustom(IList<DictionaryItem> customMetaTags)
         {
-            if (!string.IsNullOrWhiteSpace(metaTags.Title))
+            if (customMetaTags == null)
+            {
+                return;
+            }
+
+            foreach (var metaTag in customMetaTags)
+            {
+                _resourceManager.RegisterMeta(new MetaEntry { Name = metaTag.Name, Content = metaTag.Value });
+            }
+        }
+
+        public void RegisterDefaults(MetaTagsPart metaTags, IList<DictionaryItem> customMetaTags = null)
+        {
+            if (!string.IsNullOrWhiteSpace(metaTags.Title) && !HasCustomMetaTag(customMetaTags, "title"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Name = "title", Content = metaTags.Title });
             }
 
-            if (!string.IsNullOrWhiteSpace(metaTags.Description))
+            if (!string.IsNullOrWhiteSpace(metaTags.Description) && !HasCustomMetaTag(customMetaTags, "description"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Name = "description", Content = metaTags.Description });
             }
         }
 
-        public void RegisterOpenGraph(MetaTagsPart metaTags)
+        public void RegisterOpenGraph(MetaTagsPart metaTags, IList<DictionaryItem> customMetaTags = null)
         {
-            _resourceManager.RegisterMeta(new MetaEntry { Name = "og:type", Content = "website" });
-            _resourceManager.RegisterMeta(new MetaEntry { Name = "og:url", Content = GetPageUrl() });
+            if (!HasCustomMetaTag(customMetaTags, "og:type"))
+            {
+                _resourceManager.RegisterMeta(new MetaEntry { Name = "og:type", Content = "website" });
+            }
 
-            if (!string.IsNullOrWhiteSpace(metaTags.Title))
+            if (!HasCustomMetaTag(customMetaTags, "og:url"))
+            {
+                _resourceManager.RegisterMeta(new MetaEntry { Name = "og:url", Content = GetPageUrl() });
+            }
+
+            if (!string.IsNullOrWhiteSpace(metaTags.Title) && !HasCustomMetaTag(customMetaTags, "og:title"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Name = "og:title", Content = metaTags.Title });
             }
 
-            if (!string.IsNullOrWhiteSpace(metaTags.Description))
+            if (!string.IsNullOrWhiteSpace(metaTags.Description) && !HasCustomMetaTag(customMetaTags, "og:description"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Name = "og:description", Content = metaTags.Description });
             }
 
-            if (metaTags.Images != null && metaTags.Images.Any())
+            if (metaTags.Images != null && metaTags.Images.Any() && !HasCustomMetaTag(customMetaTags, "og:image"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Name = "og:image", Content = GetMediaUrl(metaTags.Images[0]) });
             }
         }
 
-        public void RegisterTwitter(MetaTagsPart metaTags)
+        public void RegisterTwitter(MetaTagsPart metaTags, IList<DictionaryItem> customMetaTags = null)
         {
-            _resourceManager.RegisterMeta(new MetaEntry { Name = "twitter:card", Content = "summary_large_image" });
-            _resourceManager.RegisterMeta(new MetaEntry { Name = "twitter:url", Content = GetPageUrl() });
+            if (!HasCustomMetaTag(customMetaTags, "twitter:card"))
+            {
+                _resourceManager.RegisterMeta(new MetaEntry { Name = "twitter:card", Content = "summary_large_image" });
+            }
 
-            if (!string.IsNullOrWhiteSpace(metaTags.Title))
+            if (!HasCustomMetaTag(customMetaTags, "twitter:url"))
+            {
+                _resourceManager.RegisterMeta(new MetaEntry { Name = "twitter:url", Content = GetPageUrl() });
+            }
+
+            if (!string.IsNullOrWhiteSpace(metaTags.Title) && !HasCustomMetaTag(customMetaTags, "twitter:title"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Name = "twitter:title", Content = metaTags.Title });
             }
 
-            if (!string.IsNullOrWhiteSpace(metaTags.Description))
+            if (!string.IsNullOrWhiteSpace(metaTags.Description) && !HasCustomMetaTag(customMetaTags, "twitter:description"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Name = "twitter:description", Content = metaTags.Description });
             }
 
-            if (metaTags.Images != null && metaTags.Images.Any())
+            if (metaTags.Images != null && metaTags.Images.Any() && !HasCustomMetaTag(customMetaTags, "twitter:image"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Name = "twitter:image", Content = GetMediaUrl(metaTags.Images[0]) });
             }
@@ -104,6 +135,16 @@ namespace Etch.OrchardCore.SEO.MetaTags.Services
         {
             var request = _httpContextAccessor.HttpContext.Request;
             return $"{GetHostUrl()}{request.PathBase}{request.Path}";
+        }
+
+        private bool HasCustomMetaTag(IList<DictionaryItem> customMetaTags, string name)
+        {
+            if (customMetaTags == null)
+            {
+                return false;
+            }
+
+            return customMetaTags.Any(x => string.Equals(x.Name, name, StringComparison.InvariantCultureIgnoreCase));
         }
 
         #endregion

--- a/placement.json
+++ b/placement.json
@@ -1,0 +1,8 @@
+{
+  "DictionaryField_Edit": [
+    {
+      "place": "Actions:1",
+      "contentPart": [ "MetaTagsPart" ]
+    }
+  ]
+}


### PR DESCRIPTION
Added a dictionary field (named "Custom") to the `MetaTagsPart` that editors can use to define custom meta tags. Any meta tags defined in the custom dictionary field will take precedence over the default meta tags that get added when specifying an image, title or description.