### PR TITLE
Fix/custom field display name

### DIFF
--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.4.5-beta</Version>
+    <Version>0.4.6-beta</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>

--- a/MetaTags/Migrations.cs
+++ b/MetaTags/Migrations.cs
@@ -29,6 +29,7 @@ namespace Etch.OrchardCore.SEO.MetaTags
             _contentDefinitionManager.AlterPartDefinition("MetaTagsPart", builder => builder
                 .WithField(Constants.CustomFieldName, field => field
                     .OfType(typeof(DictionaryField).Name)
+                    .WithDisplayName(Constants.CustomFieldName)
                     .WithSetting("Hint", "Apply custom meta tags that will override the defaults applied through defining image, title & description.")
                 )
             );


### PR DESCRIPTION
Custom field on `MetaTagsPart` is displaying as "Dictionary Field", changed it to be "Custom".