### PR TITLE
Fix custom meta tags trying to display

### DIFF
--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.4.6-beta</Version>
+    <Version>0.4.7-beta</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>

--- a/placement.json
+++ b/placement.json
@@ -4,5 +4,11 @@
       "place": "Actions:1",
       "contentPart": [ "MetaTagsPart" ]
     }
+  ],
+  "DictionaryField": [
+    {
+      "place": "-",
+      "contentPart": [ "MetaTagsPart" ]
+    }
   ]
 }


### PR DESCRIPTION
Noticed as there is actually an issue with the dictionary field when rendering that was causing pages to not render. The custom dictionary field will no longer render when displaying a meta tags part.