### PR TITLE
Add ability to redirect to/from homepage by using “/”

### DIFF
--- a/Controllers/RedirectController.cs
+++ b/Controllers/RedirectController.cs
@@ -3,6 +3,8 @@ using Etch.OrchardCore.SEO.Redirects.Models;
 using OrchardCore.ContentManagement;
 using OrchardCore.Modules;
 using System.Threading.Tasks;
+using OrchardCore.Environment.Shell;
+using Etch.OrchardCore.SEO.Redirects.Services;
 
 namespace Etch.OrchardCore.SEO.Controllers
 {
@@ -12,14 +14,16 @@ namespace Etch.OrchardCore.SEO.Controllers
         #region Dependencies
 
         private readonly IContentManager _contentManager;
+        private readonly ITenantService _tenantService;
 
         #endregion
 
         #region Constructor
 
-        public RedirectController(IContentManager contentManager)
+        public RedirectController(IContentManager contentManager, ITenantService tenantService)
         {
             _contentManager = contentManager;
+            _tenantService = tenantService;
         }
 
         #endregion
@@ -36,6 +40,11 @@ namespace Etch.OrchardCore.SEO.Controllers
             }
 
             var part = contentItem.As<RedirectPart>();
+
+            if (part.ToUrl.StartsWith("/", System.StringComparison.Ordinal))
+            {
+                return new RedirectResult($"{_tenantService.GetTenantUrl()}{part.ToUrl}", part.IsPermanent);
+            }
 
             return new RedirectResult(part.ToUrl, part.IsPermanent);
         }

--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.5.1-rc1</Version>
+    <Version>0.5.2-rc1</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ _Under development_
 
 Create redirect content items that'll redirect a relative URL to another URL.
 
+#### Known Issues
+
+When creating a content item to redirect from homepage to another page, you need to make sure to disable the `Home Route` Module to make the redirect work correctly.
+
 #### Import
 
 This feature adds the ability to bulk import redirects from an XLSX file.

--- a/Redirects/Drivers/RedirectPartDisplay.cs
+++ b/Redirects/Drivers/RedirectPartDisplay.cs
@@ -1,4 +1,5 @@
 ﻿using Etch.OrchardCore.SEO.Redirects.Models;
+using Etch.OrchardCore.SEO.Redirects.Services;
 using Etch.OrchardCore.SEO.Redirects.Validation;
 using Etch.OrchardCore.SEO.Redirects.ViewModels;
 using Microsoft.Extensions.Localization;
@@ -16,14 +17,16 @@ namespace Etch.OrchardCore.SEO.Redirects.Drivers
         # region Dependencies
 
         private readonly IStringLocalizer<RedirectPartDisplay> T;
+        private readonly ITenantService _tenantService;
 
         #endregion
 
         #region Constructor
 
-        public RedirectPartDisplay(IStringLocalizer<RedirectPartDisplay> localizer)
+        public RedirectPartDisplay(IStringLocalizer<RedirectPartDisplay> localizer, ITenantService tenantService)
         {
             T = localizer;
+            _tenantService = tenantService;
         }
 
         #endregion
@@ -34,9 +37,10 @@ namespace Etch.OrchardCore.SEO.Redirects.Drivers
         {
             return Initialize<RedirectPartEditViewModel>("RedirectPart_Edit", model =>
             {
-                model.FromUrl = UrlValidation.CleanFromUrl(part.FromUrl);
+                model.FromUrl = part.FromUrl;
                 model.ToUrl = part.ToUrl;
                 model.IsPermanent = part.ContentItem.Id == 0 ? true : part.IsPermanent;
+                model.TenantUrl = _tenantService.GetTenantUrl();
 
                 return Task.CompletedTask;
             });
@@ -64,11 +68,6 @@ namespace Etch.OrchardCore.SEO.Redirects.Drivers
 
         private void ValidateUrls(RedirectPart part, IUpdateModel updater)
         {
-            if (!UrlValidation.IsRelativeUrl(part.FromUrl))
-            {
-                updater.ModelState.AddModelError(Prefix, nameof(part.FromUrl), T["Your From URL must be relative"]);
-            }
-
             if (!UrlValidation.ValidFromUrl(part.FromUrl))
             {
                 var invalidCharactersForMessage = string.Join(", ", UrlValidation.InvalidCharactersForFromUrl.Select(c => $"\"{c}\""));

--- a/Redirects/Import/Services/ImportRedirectsService.cs
+++ b/Redirects/Import/Services/ImportRedirectsService.cs
@@ -101,7 +101,7 @@ namespace Etch.OrchardCore.SEO.Redirects.Import.Services
 
             redirectItem.Author = _httpContextAccessor.HttpContext.User.Identity.Name;
             redirectItem.DisplayText = row.Title;
-            redirectPart.FromUrl = UrlValidation.CleanFromUrl(row.FromUrl)?.Trim();
+            redirectPart.FromUrl = row.FromUrl?.Trim();
             redirectPart.ToUrl = row.ToUrl?.Trim();
             redirectPart.IsPermanent = true;
             redirectPart.Apply();

--- a/Redirects/Routing/RedirectRouteTransformer.cs
+++ b/Redirects/Routing/RedirectRouteTransformer.cs
@@ -21,7 +21,8 @@ namespace Etch.OrchardCore.SEO.Redirects.Routing
 
         public override ValueTask<RouteValueDictionary> TransformAsync(HttpContext httpContext, RouteValueDictionary values)
         {
-            if (_entries.TryGetContentItemId(httpContext.Request.Path.ToString().TrimEnd('/'), out var contentItemId))
+            var contentItemId = GetContentItemId(httpContext);
+            if (!string.IsNullOrEmpty(contentItemId))
             {
                 return new ValueTask<RouteValueDictionary>(new RouteValueDictionary {
                     {"Area", "Etch.OrchardCore.SEO"},
@@ -32,6 +33,22 @@ namespace Etch.OrchardCore.SEO.Redirects.Routing
             }
 
             return new ValueTask<RouteValueDictionary>((RouteValueDictionary)null);
+        }
+
+        private string GetContentItemId(HttpContext httpContext)
+        {
+            var url = httpContext.Request.Path.ToString().TrimEnd('/');
+            if (string.IsNullOrEmpty(url) && _entries.TryGetContentItemId("/", out var contentItemId))
+            {
+                return contentItemId;
+            }
+
+            if (_entries.TryGetContentItemId(url, out var contentItem))
+            {
+                return contentItem;
+            }
+
+            return null;
         }
     }
 }

--- a/Redirects/Services/ITenantService.cs
+++ b/Redirects/Services/ITenantService.cs
@@ -1,0 +1,7 @@
+﻿namespace Etch.OrchardCore.SEO.Redirects.Services
+{
+    public interface ITenantService
+    {
+        string GetTenantUrl();
+    }
+}

--- a/Redirects/Services/TenantService.cs
+++ b/Redirects/Services/TenantService.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using OrchardCore.Environment.Shell;
+
+namespace Etch.OrchardCore.SEO.Redirects.Services
+{
+    public class TenantService : ITenantService
+    {
+        #region Dependencies
+
+        private readonly ShellSettings _currentShellSettings;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        #endregion
+
+        #region Constructor
+
+        public TenantService(ShellSettings currentShellSettings, IHttpContextAccessor httpContextAccessor)
+        {
+            _currentShellSettings = currentShellSettings;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        #endregion
+
+
+        public string GetTenantUrl()
+        {
+            var requestHostInfo = _httpContextAccessor.HttpContext.Request.Host;
+            var tenantUrlHost = _currentShellSettings.RequestUrlHost?.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? requestHostInfo.Host;
+
+            if (requestHostInfo.Port.HasValue)
+            {
+                tenantUrlHost += ":" + requestHostInfo.Port;
+            }
+
+            var result = $"{_httpContextAccessor.HttpContext.Request.Scheme}://{tenantUrlHost}";
+
+            if (!string.IsNullOrEmpty(_currentShellSettings.RequestUrlPrefix))
+            {
+                result += "/" + _currentShellSettings.RequestUrlPrefix;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Redirects/Startup.cs
+++ b/Redirects/Startup.cs
@@ -33,6 +33,7 @@ namespace Etch.OrchardCore.SEO.Redirects
             services.AddSingleton<ContentPart, RedirectPart>();
             services.AddSingleton<IIndexProvider, RedirectPartIndexProvider>();
             services.AddSingleton<IRedirectEntries, RedirectEntries>();
+            services.AddSingleton<ITenantService, TenantService>();
 
             services.AddScoped<IDataMigration, Migrations>();
 

--- a/Redirects/Validation/UrlValidation.cs
+++ b/Redirects/Validation/UrlValidation.cs
@@ -13,14 +13,6 @@ namespace Etch.OrchardCore.SEO.Redirects.Validation
 
         #endregion
 
-        public static string CleanFromUrl(string url)
-        {
-            if (string.IsNullOrWhiteSpace(url))
-                return url;
-
-            return url.StartsWith("/") ? url.Substring(1) : url;
-        }
-
         public static bool IsRelativeUrl(string url)
         {
             Uri result;

--- a/Redirects/ViewModels/RedirectPartEditViewModel.cs
+++ b/Redirects/ViewModels/RedirectPartEditViewModel.cs
@@ -11,5 +11,7 @@ namespace Etch.OrchardCore.SEO.Redirects.ViewModels
         public string ToUrl { get; set; }
 
         public bool IsPermanent { get; set; }
+
+        public string TenantUrl { get; set; }
     }
 }

--- a/Views/RedirectPart.Edit.cshtml
+++ b/Views/RedirectPart.Edit.cshtml
@@ -4,7 +4,12 @@
 
 <fieldset class="form-group" asp-validation-class-for="FromUrl">
     <label asp-for="FromUrl">@T["From Url"] <span asp-validation-for="FromUrl"></span></label>
-    <input asp-for="FromUrl" class="form-control content-preview-text content-caption-text" />
+    <div class="input-group">
+        <div class="input-group-prepend">
+            <span class="input-group-text" id="basic-addon3">@Model.TenantUrl</span>
+        </div>
+        <input asp-for="FromUrl" class="form-control content-preview-text content-caption-text" />
+    </div>
     <span class="hint">@T["Relative URL that triggers redirect."]</span>
 </fieldset>
 


### PR DESCRIPTION
- Bump version to 0.6.0-rc1.
- Add tenant URL to the from field.
- From url field now accepts “/“ to redirect to hompage and both “/foo“ and “foo” are acceptable.
- To url field now accepts “/” to redirect to homepage as well as “foo” or “/foo“ or external URLs