### PR TITLE
Fix meta tags not saving when defining image

### DIFF
--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc1-10004" />
     <PackageReference Include="OrchardCore.ContentManagement.Display" Version="1.0.0-rc1-10004" />
     <PackageReference Include="OrchardCore.Data.Abstractions" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Media" Version="1.0.0-rc1-10004" />
     <PackageReference Include="OrchardCore.Media.Services" Version="1.0.0-rc1-10004" />
     <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc1-10004" />
     <PackageReference Include="OrchardCore.Navigation.Core" Version="1.0.0-rc1-10004" />

--- a/MetaTags/Drivers/MetaTagsPartDisplay.cs
+++ b/MetaTags/Drivers/MetaTagsPartDisplay.cs
@@ -6,6 +6,7 @@ using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Display.Models;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Media.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -52,10 +53,12 @@ namespace Etch.OrchardCore.SEO.MetaTags.Drivers
 
         public override IDisplayResult Edit(MetaTagsPart metaTagsPart)
         {
+            var itemPaths = metaTagsPart.Images?.ToList().Select(p => new EditMediaFieldItemInfo { Path = p }) ?? new EditMediaFieldItemInfo[] { };
+
             return Initialize<MetaTagsPartViewModel>("MetaTagsPart_Edit", model =>
             {
                 model.Description = metaTagsPart.Description;
-                model.Images = JsonConvert.SerializeObject(metaTagsPart.Images?.ToList() ?? new List<string>());
+                model.Images = JsonConvert.SerializeObject(itemPaths);
                 model.Title = metaTagsPart.Title;
                 return Task.CompletedTask;
             })
@@ -73,7 +76,7 @@ namespace Etch.OrchardCore.SEO.MetaTags.Drivers
 
                 part.Images = string.IsNullOrWhiteSpace(model.Images)
                     ? Array.Empty<string>()
-                    : JsonConvert.DeserializeObject<IList<string>>(model.Images).ToArray();
+                    : JsonConvert.DeserializeObject<IList<EditMediaFieldItemInfo>>(model.Images).Select(x => x.Path).ToArray();
 
             }
 


### PR DESCRIPTION
Orchard Core changed the structure of data submitted for media field in their latest update. Updating the driver to cater for this solves the issue.

Fixes #41.