### PR TITLE
Fix meta image not loading correct image for LinkedIn

### DIFF
--- a/MetaTags/Services/MetaTagsService.cs
+++ b/MetaTags/Services/MetaTagsService.cs
@@ -59,7 +59,7 @@ namespace Etch.OrchardCore.SEO.MetaTags.Services
 
             if (metaTags.Images != null && metaTags.Images.Any())
             {
-                _resourceManager.RegisterMeta(new MetaEntry { Name = "og:image", Content = GetMediaUrl(metaTags.Images[0]) });
+                _resourceManager.RegisterMeta(new MetaEntry { Name = "image", Content = GetMediaUrl(metaTags.Images[0]), Property = "og:image" });
             }
         }
 


### PR DESCRIPTION
Open Graph meta tag for loading the image wasn't in the correct format
so LinkedIn was using the first image it finds in the `<body>`.

Below is the original open graph image meta tags.

```
<meta content="..." name="og:image" />
```

This is the correct format that will now be displaying.

```
<meta content="..." name="image" property="og:image">
```