### PR TITLE
Fix Redirecting to a URL with slash at the start not working correctly

### DIFF
--- a/Controllers/RedirectController.cs
+++ b/Controllers/RedirectController.cs
@@ -16,7 +16,7 @@ namespace Etch.OrchardCore.SEO.Controllers
         private readonly IContentManager _contentManager;
         private readonly ITenantService _tenantService;
 
-        #endregion
+        #endregion Dependencies
 
         #region Constructor
 
@@ -26,7 +26,7 @@ namespace Etch.OrchardCore.SEO.Controllers
             _tenantService = tenantService;
         }
 
-        #endregion
+        #endregion Constructor
 
         #region Actions
 
@@ -40,15 +40,16 @@ namespace Etch.OrchardCore.SEO.Controllers
             }
 
             var part = contentItem.As<RedirectPart>();
+            var toUrl = part.ToUrl;
 
-            if (part.ToUrl.StartsWith("/", System.StringComparison.Ordinal))
+            if (!toUrl.StartsWith("/", System.StringComparison.Ordinal))
             {
-                return new RedirectResult($"{_tenantService.GetTenantUrl()}{part.ToUrl}", part.IsPermanent);
+                toUrl = $"/{toUrl}";
             }
 
-            return new RedirectResult(part.ToUrl, part.IsPermanent);
+            return new RedirectResult($"{_tenantService.GetTenantUrl()}{toUrl}", part.IsPermanent);
         }
 
-        #endregion
+        #endregion Actions
     }
 }


### PR DESCRIPTION
The example I was using for this was a FromUrl of `/test/go-to-news` and a ToUrl of `news/news-a` however this'll currently end up on `/test/news/news-a`, this commit should make it go to `/news/news-a` as intended.