### PR TITLE
Upgrade to RC2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 mono: none
 dist: bionic
-dotnet: 3.0
+dotnet: 3.1
 
 install:
     - dotnet restore

--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.5.5-rc1</Version>
+    <Version>0.6.0-rc2</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>
@@ -16,16 +16,15 @@
 
   <ItemGroup>
     <PackageReference Include="FluentExcel" Version="2.2.0" />
-    <PackageReference Include="OrchardCore.Admin" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Autoroute" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.ContentManagement.Display" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Data.Abstractions" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Media" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Media.Services" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.Navigation.Core" Version="1.0.0-rc1-10004" />
-    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Admin" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Autoroute" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.ContentManagement.Display" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Data.Abstractions" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Media" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.Navigation.Core" Version="1.0.0-rc2-13450" />
+    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-rc2-13450" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "SEO",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "0.5.5"
+    Version = "0.6.0"
 )]
 
 [assembly: Feature(

--- a/MetaTags/Drivers/MetaTagsPartDisplay.cs
+++ b/MetaTags/Drivers/MetaTagsPartDisplay.cs
@@ -60,7 +60,6 @@ namespace Etch.OrchardCore.SEO.MetaTags.Drivers
                 model.Description = metaTagsPart.Description;
                 model.Images = JsonConvert.SerializeObject(itemPaths);
                 model.Title = metaTagsPart.Title;
-                return Task.CompletedTask;
             })
             .Location("Parts#SEO:10");
         }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Module for [Orchard Core](https://github.com/OrchardCMS/OrchardCore) that provid
 
 ## Orchard Core Reference
 
-This module is referencing the RC1 build of Orchard Core ([`1.0.0-rc1-10004`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc1-10004)).
+This module is referencing the RC2 build of Orchard Core ([`1.0.0-rc2-13450`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc2-13450)).
 
 ## Features
 

--- a/Redirects/Drivers/RedirectPartDisplay.cs
+++ b/Redirects/Drivers/RedirectPartDisplay.cs
@@ -41,8 +41,6 @@ namespace Etch.OrchardCore.SEO.Redirects.Drivers
                 model.ToUrl = part.ToUrl;
                 model.IsPermanent = part.ContentItem.Id == 0 ? true : part.IsPermanent;
                 model.TenantUrl = _tenantService.GetTenantUrl();
-
-                return Task.CompletedTask;
             });
         }
 

--- a/Redirects/Routing/RedirectRouteTransformer.cs
+++ b/Redirects/Routing/RedirectRouteTransformer.cs
@@ -11,17 +11,16 @@ namespace Etch.OrchardCore.SEO.Redirects.Routing
     public class RedirectRouteTransformer : DynamicRouteValueTransformer
     {
         private readonly IRedirectEntries _entries;
-        private readonly AutorouteOptions _options;
 
-        public RedirectRouteTransformer(IRedirectEntries entries, IOptions<AutorouteOptions> options)
+        public RedirectRouteTransformer(IRedirectEntries entries)
         {
             _entries = entries;
-            _options = options.Value;
         }
 
         public override ValueTask<RouteValueDictionary> TransformAsync(HttpContext httpContext, RouteValueDictionary values)
         {
             var contentItemId = GetContentItemId(httpContext);
+
             if (!string.IsNullOrEmpty(contentItemId))
             {
                 return new ValueTask<RouteValueDictionary>(new RouteValueDictionary {
@@ -37,15 +36,17 @@ namespace Etch.OrchardCore.SEO.Redirects.Routing
 
         private string GetContentItemId(HttpContext httpContext)
         {
+            AutorouteEntry entry;
             var url = httpContext.Request.Path.ToString().TrimEnd('/');
-            if (string.IsNullOrEmpty(url) && _entries.TryGetContentItemId("/", out var contentItemId))
+
+            if (string.IsNullOrEmpty(url) && _entries.TryGetEntryByPath("/", out entry))
             {
-                return contentItemId;
+                return entry.ContentItemId;
             }
 
-            if (_entries.TryGetContentItemId(url, out var contentItem))
+            if (_entries.TryGetEntryByPath(url, out entry))
             {
-                return contentItem;
+                return entry.ContentItemId;
             }
 
             return null;

--- a/Redirects/Services/RedirectEntriesExtensions.cs
+++ b/Redirects/Services/RedirectEntriesExtensions.cs
@@ -6,12 +6,12 @@ namespace Etch.OrchardCore.SEO.Redirects.Services
     {
         public static void AddEntry(this IRedirectEntries entries, string contentItemId, string path)
         {
-            entries.AddEntries(new[] { new AutorouteEntry { ContentItemId = contentItemId, Path = path } });
+            entries.AddEntries(new[] { new AutorouteEntry(contentItemId, path) });
         }
 
         public static void RemoveEntry(this IRedirectEntries entries, string contentItemId, string path)
         {
-            entries.RemoveEntries(new[] { new AutorouteEntry { ContentItemId = contentItemId, Path = path } });
+            entries.RemoveEntries(new[] { new AutorouteEntry(contentItemId, path) });
         }
     }
 }

--- a/Redirects/Startup.cs
+++ b/Redirects/Startup.cs
@@ -46,7 +46,7 @@ namespace Etch.OrchardCore.SEO.Redirects
             var session = serviceProvider.GetRequiredService<ISession>();
             var redirects = session.QueryIndex<RedirectPartIndex>(o => o.Published).ListAsync().GetAwaiter().GetResult();
 
-            entries.AddEntries(redirects.Select(x => new AutorouteEntry { ContentItemId = x.ContentItemId, Path = x.Url }));
+            entries.AddEntries(redirects.Select(x => new AutorouteEntry(x.ContentItemId, x.Url)));
 
             // The 1st segment prevents the transformer to be executed for the home.
             routes.MapDynamicControllerRoute<RedirectRouteTransformer>("/{**slug}");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "moov2.orchardcore.seo",
-    "version": "0.5.5",
+    "version": "0.6.0",
     "description": "Module for Orchard Core that provides useful features for SEO (search engine optimisation).",
     "scripts": {
         "build": "webpack"


### PR DESCRIPTION
- Update target framework to 3.1
- Update Travis build script to target 3.1
- Update references to latest Orchard Core version
- Fix compilation issues due to API changes
    - Update anonymous functions in drivers to no longer return
    - Update `AutoEntry` to use constructor variables
    - Use `TryGetEntryByPath` instead of `TryGetEntryByContentItemId`
      in implementation of `DynamicRouteValueTransformer`