### PR TITLE
Add ability to define custom meta tags

### DIFF
--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.6.1-rc2</Version>
+    <Version>0.6.2-rc2</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Etch.OrchardCore.Fields" Version="0.8.1-rc1" />
     <PackageReference Include="FluentExcel" Version="2.2.0" />
     <PackageReference Include="OrchardCore.Admin" Version="1.0.0-rc2-13450" />
     <PackageReference Include="OrchardCore.Autoroute" Version="1.0.0-rc2-13450" />

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "SEO",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "0.6.1"
+    Version = "0.6.2"
 )]
 
 [assembly: Feature(
@@ -49,6 +49,7 @@ using OrchardCore.Modules.Manifest;
     Name = "Meta Tags",
     Dependencies = new[]
     {
+        "Etch.OrchardCore.Fields.Dictionary",
         "OrchardCore.Media"
     },
     Description = "Manage meta tags for content items.",

--- a/MetaTags/Constants.cs
+++ b/MetaTags/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace Etch.OrchardCore.SEO.MetaTags
+{
+    public class Constants
+    {
+        public const string CustomFieldName = "Custom";
+    }
+}

--- a/MetaTags/Drivers/MetaTagsPartDisplay.cs
+++ b/MetaTags/Drivers/MetaTagsPartDisplay.cs
@@ -1,4 +1,5 @@
-﻿using Etch.OrchardCore.SEO.MetaTags.Models;
+﻿using Etch.OrchardCore.SEO.MetaTags.Extensions;
+using Etch.OrchardCore.SEO.MetaTags.Models;
 using Etch.OrchardCore.SEO.MetaTags.Services;
 using Etch.OrchardCore.SEO.MetaTags.ViewModels;
 using Newtonsoft.Json;
@@ -40,9 +41,12 @@ namespace Etch.OrchardCore.SEO.MetaTags.Drivers
                 return null;
             }
 
-            _metaTagsService.RegisterDefaults(metaTagsPart);
-            _metaTagsService.RegisterOpenGraph(metaTagsPart);
-            _metaTagsService.RegisterTwitter(metaTagsPart);
+            var customMetaTags = metaTagsPart.GetDictionaryFieldValue(Constants.CustomFieldName);
+
+            _metaTagsService.RegisterCustom(customMetaTags);
+            _metaTagsService.RegisterDefaults(metaTagsPart, customMetaTags);
+            _metaTagsService.RegisterOpenGraph(metaTagsPart, customMetaTags);
+            _metaTagsService.RegisterTwitter(metaTagsPart, customMetaTags);
 
             return Initialize<MetaTagsPartViewModel>("MetaTagsPart", model =>
             {

--- a/MetaTags/Extensions/DictionaryFieldExtensions.cs
+++ b/MetaTags/Extensions/DictionaryFieldExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Etch.OrchardCore.Fields.Dictionary.Fields;
+using Etch.OrchardCore.Fields.Dictionary.Models;
+using OrchardCore.ContentManagement;
+using System.Collections.Generic;
+
+namespace Etch.OrchardCore.SEO.MetaTags.Extensions
+{
+    public static class DictionaryFieldExtensions
+    {
+        public static IList<DictionaryItem> GetDictionaryFieldValue(this ContentPart part, string name)
+        {
+            return part?.Get<DictionaryField>(name)?.Data;
+        }
+    }
+}

--- a/MetaTags/Migrations.cs
+++ b/MetaTags/Migrations.cs
@@ -1,6 +1,8 @@
 ﻿using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Data.Migration;
+using Etch.OrchardCore.Fields.Dictionary.Fields;
+using Etch.OrchardCore.Fields.Dictionary.Settings;
 
 namespace Etch.OrchardCore.SEO.MetaTags
 {
@@ -20,6 +22,23 @@ namespace Etch.OrchardCore.SEO.MetaTags
                 .WithDescription("Provides meta tags for your content item."));
 
             return 1;
+        }
+
+        public int UpdateFrom1()
+        {
+
+            _contentDefinitionManager.AlterPartDefinition("MetaTagsPart", builder => builder
+                .WithField(Constants.CustomFieldName, field => field
+                    .OfType(typeof(DictionaryField).Name)
+                    .WithDisplayName(Constants.CustomFieldName)
+                    .WithSettings(new DictionaryFieldSettings
+                    {
+                        Hint = "Apply custom meta tags that will override the defaults applied through defining image, title & description."
+                    })
+                )
+            );
+
+            return 2;
         }
     }
 }

--- a/MetaTags/Services/IMetaTagsService.cs
+++ b/MetaTags/Services/IMetaTagsService.cs
@@ -1,11 +1,14 @@
-﻿using Etch.OrchardCore.SEO.MetaTags.Models;
+﻿using Etch.OrchardCore.Fields.Dictionary.Models;
+using Etch.OrchardCore.SEO.MetaTags.Models;
+using System.Collections.Generic;
 
 namespace Etch.OrchardCore.SEO.MetaTags.Services
 {
     public interface IMetaTagsService
     {
-        void RegisterDefaults(MetaTagsPart metaTags);
-        void RegisterOpenGraph(MetaTagsPart metaTags);
-        void RegisterTwitter(MetaTagsPart metaTags);
+        void RegisterDefaults(MetaTagsPart metaTags, IList<DictionaryItem> customMetaTags = null);
+        void RegisterOpenGraph(MetaTagsPart metaTags, IList<DictionaryItem> customMetaTags = null);
+        void RegisterTwitter(MetaTagsPart metaTags, IList<DictionaryItem> customMetaTags = null);
+        void RegisterCustom(IList<DictionaryItem> customMetaTags);
     }
 }

--- a/MetaTags/Services/MetaTagsService.cs
+++ b/MetaTags/Services/MetaTagsService.cs
@@ -3,6 +3,9 @@ using Etch.OrchardCore.SEO.MetaTags.Models;
 using OrchardCore.Media;
 using OrchardCore.ResourceManagement;
 using System.Linq;
+using Etch.OrchardCore.Fields.Dictionary.Models;
+using System.Collections.Generic;
+using System;
 
 namespace Etch.OrchardCore.SEO.MetaTags.Services
 {
@@ -29,56 +32,83 @@ namespace Etch.OrchardCore.SEO.MetaTags.Services
 
         #region Implementation
 
-        public void RegisterDefaults(MetaTagsPart metaTags)
+        public void RegisterCustom(IList<DictionaryItem> customMetaTags)
         {
-            if (!string.IsNullOrWhiteSpace(metaTags.Title))
+            if (customMetaTags == null)
+            {
+                return;
+            }
+
+            foreach (var metaTag in customMetaTags)
+            {
+                _resourceManager.RegisterMeta(new MetaEntry { Name = metaTag.Name, Content = metaTag.Value });
+            }
+        }
+
+        public void RegisterDefaults(MetaTagsPart metaTags, IList<DictionaryItem> customMetaTags = null)
+        {
+            if (!string.IsNullOrWhiteSpace(metaTags.Title) && !HasCustomMetaTag(customMetaTags, "title"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Name = "title", Content = metaTags.Title });
             }
 
-            if (!string.IsNullOrWhiteSpace(metaTags.Description))
+            if (!string.IsNullOrWhiteSpace(metaTags.Description) && !HasCustomMetaTag(customMetaTags, "description"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Name = "description", Content = metaTags.Description });
             }
         }
 
-        public void RegisterOpenGraph(MetaTagsPart metaTags)
+        public void RegisterOpenGraph(MetaTagsPart metaTags, IList<DictionaryItem> customMetaTags = null)
         {
-            _resourceManager.RegisterMeta(new MetaEntry { Property = "og:type", Content = "website" });
-            _resourceManager.RegisterMeta(new MetaEntry { Property = "og:url", Content = GetPageUrl() });
+            if (!HasCustomMetaTag(customMetaTags, "og:type"))
+            {
+                _resourceManager.RegisterMeta(new MetaEntry { Property = "og:type", Content = "website" });
+            }
 
-            if (!string.IsNullOrWhiteSpace(metaTags.Title))
+            if (!HasCustomMetaTag(customMetaTags, "og:url"))
+            {
+                _resourceManager.RegisterMeta(new MetaEntry { Property = "og:url", Content = GetPageUrl() });
+            }
+
+            if (!string.IsNullOrWhiteSpace(metaTags.Title) && !HasCustomMetaTag(customMetaTags, "og:title"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Property = "og:title", Content = metaTags.Title });
             }
 
-            if (!string.IsNullOrWhiteSpace(metaTags.Description))
+            if (!string.IsNullOrWhiteSpace(metaTags.Description) && !HasCustomMetaTag(customMetaTags, "og:description"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Property = "og:description", Content = metaTags.Description });
             }
 
-            if (metaTags.Images != null && metaTags.Images.Any())
+            if (metaTags.Images != null && metaTags.Images.Any() && !HasCustomMetaTag(customMetaTags, "og:image"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Property = "og:image", Content = GetMediaUrl(metaTags.Images[0]) });
             }
         }
 
-        public void RegisterTwitter(MetaTagsPart metaTags)
+        public void RegisterTwitter(MetaTagsPart metaTags, IList<DictionaryItem> customMetaTags = null)
         {
-            _resourceManager.RegisterMeta(new MetaEntry { Property = "twitter:card", Content = "summary_large_image" });
-            _resourceManager.RegisterMeta(new MetaEntry { Property = "twitter:url", Content = GetPageUrl() });
+            if (!HasCustomMetaTag(customMetaTags, "twitter:card"))
+            {
+                _resourceManager.RegisterMeta(new MetaEntry { Property = "twitter:card", Content = "summary_large_image" });
+            }
 
-            if (!string.IsNullOrWhiteSpace(metaTags.Title))
+            if (!HasCustomMetaTag(customMetaTags, "twitter:url"))
+            {
+                _resourceManager.RegisterMeta(new MetaEntry { Property = "twitter:url", Content = GetPageUrl() });
+            }
+
+            if (!string.IsNullOrWhiteSpace(metaTags.Title) && !HasCustomMetaTag(customMetaTags, "twitter:title"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Property = "twitter:title", Content = metaTags.Title });
             }
 
-            if (!string.IsNullOrWhiteSpace(metaTags.Description))
+            if (!string.IsNullOrWhiteSpace(metaTags.Description) && !HasCustomMetaTag(customMetaTags, "twitter:description"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Property = "twitter:description", Content = metaTags.Description });
             }
 
-            if (metaTags.Images != null && metaTags.Images.Any())
+            if (metaTags.Images != null && metaTags.Images.Any() && !HasCustomMetaTag(customMetaTags, "twitter:image"))
             {
                 _resourceManager.RegisterMeta(new MetaEntry { Property = "twitter:image", Content = GetMediaUrl(metaTags.Images[0]) });
             }
@@ -105,6 +135,17 @@ namespace Etch.OrchardCore.SEO.MetaTags.Services
             var request = _httpContextAccessor.HttpContext.Request;
             return $"{GetHostUrl()}{request.PathBase}{request.Path}";
         }
+
+        private bool HasCustomMetaTag(IList<DictionaryItem> customMetaTags, string name)
+        {
+            if (customMetaTags == null)
+            {
+                return false;
+            }
+
+            return customMetaTags.Any(x => string.Equals(x.Name, name, StringComparison.InvariantCultureIgnoreCase));
+        }
+
 
         #endregion
     }

--- a/placement.json
+++ b/placement.json
@@ -1,0 +1,14 @@
+{
+  "DictionaryField_Edit": [
+    {
+      "place": "Parts#SEO:15",
+      "contentPart": [ "MetaTagsPart" ]
+    }
+  ],
+  "DictionaryField": [
+    {
+      "place": "-",
+      "contentPart": [ "MetaTagsPart" ]
+    }
+  ]
+}


### PR DESCRIPTION
Add "Custom" dictionary field to `MetaTagsPart` to give content editors the ability to define custom meta tags that aren't title, description or image.