### PR TITLE
Fix dictionary fields not rendering when meta tags feature is enabled

### DIFF
--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.6.2-rc2</Version>
+    <Version>0.6.3-rc2</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "SEO",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "0.6.2"
+    Version = "0.6.3"
 )]
 
 [assembly: Feature(

--- a/placement.json
+++ b/placement.json
@@ -2,12 +2,14 @@
   "DictionaryField_Edit": [
     {
       "place": "Parts#SEO:15",
+      "differentiator": "MetaTagsPart-Custom",
       "contentPart": [ "MetaTagsPart" ]
     }
   ],
   "DictionaryField": [
     {
       "place": "-",
+      "differentiator": "MetaTagsPart-Custom",
       "contentPart": [ "MetaTagsPart" ]
     }
   ]


### PR DESCRIPTION
Currently, any dictionary field will render on the `SEO` tab, and will never render out on the front end when the Meta Tags module is enabled, this is because the `placement.json` is too vague, this commit fixes that