### PR TITLE
Add ability to block search engines via no index option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This feature adds the ability to bulk import redirects from an XLSX file.
 
 ### Robots.txt
 
-Manage contents of `/robots.txt`.
+Manage contents of `/robots.txt` or block search engines with [noindex](https://developers.google.com/search/docs/advanced/crawling/block-indexing).
 
 ## Installing
 

--- a/RobotsTxt/Drivers/RobotsTxtSettingsDisplayDriver.cs
+++ b/RobotsTxt/Drivers/RobotsTxtSettingsDisplayDriver.cs
@@ -37,7 +37,7 @@ namespace Etch.OrchardCore.SEO.RobotsTxt.Drivers
 
         #region Overrides
 
-        public override async Task<IDisplayResult> EditAsync(RobotsTxtSettings settings, BuildEditorContext context)
+        public override async Task<IDisplayResult> EditAsync(RobotsTxtSettings section, BuildEditorContext context)
         {
             var user = _httpContextAccessor.HttpContext?.User;
 
@@ -48,12 +48,13 @@ namespace Etch.OrchardCore.SEO.RobotsTxt.Drivers
 
             return Initialize<RobosTxtSettingsViewModel>("RobotsTxtSettings_Edit", model =>
             {
-                model.Mode = settings.Mode;
-                model.CustomContent = settings.CustomContent;
+                model.CustomContent = section.CustomContent;
+                model.Mode = section.Mode;
+                model.NoIndex = section.NoIndex;
             }).Location("Content:3").OnGroup(GroupId);
         }
 
-        public override async Task<IDisplayResult> UpdateAsync(RobotsTxtSettings settings, BuildEditorContext context)
+        public override async Task<IDisplayResult> UpdateAsync(RobotsTxtSettings section, BuildEditorContext context)
         {
             var user = _httpContextAccessor.HttpContext?.User;
 
@@ -68,11 +69,12 @@ namespace Etch.OrchardCore.SEO.RobotsTxt.Drivers
 
                 await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-                settings.Mode = model.Mode;
-                settings.CustomContent = model.CustomContent;
+                section.CustomContent = model.CustomContent;
+                section.Mode = model.Mode;
+                section.NoIndex = model.NoIndex;
             }
 
-            return await EditAsync(settings, context);
+            return await EditAsync(section, context);
         }
 
         #endregion

--- a/RobotsTxt/Filters/NoIndexFilter.cs
+++ b/RobotsTxt/Filters/NoIndexFilter.cs
@@ -1,0 +1,45 @@
+﻿using Etch.OrchardCore.SEO.RobotsTxt.Models;
+using Microsoft.AspNetCore.Mvc.Filters;
+using OrchardCore.Entities;
+using OrchardCore.Settings;
+using System.Threading.Tasks;
+
+namespace Etch.OrchardCore.SEO.RobotsTxt.Filters
+{
+    public class NoIndexFilter : IAsyncResultFilter
+    {
+        #region Dependencies
+
+        private readonly ISiteService _siteService;
+
+        #endregion
+
+        #region Constructor
+
+        public NoIndexFilter(ISiteService siteService)
+        {
+            _siteService = siteService;    
+        }
+
+        #endregion
+
+        #region Implementation
+
+        public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
+        {
+            var siteSettings = await _siteService.GetSiteSettingsAsync();
+            var robotsSettings = siteSettings.As<RobotsTxtSettings>();
+
+            if (robotsSettings == null || !robotsSettings.NoIndex)
+            {
+                await next.Invoke();
+                return;
+            }
+
+            context.HttpContext.Response.Headers.Add("X-Robots-Tag", "noindex");
+            await next.Invoke();
+        }
+
+        #endregion
+    }
+}

--- a/RobotsTxt/Models/RobotsTxtSettings.cs
+++ b/RobotsTxt/Models/RobotsTxtSettings.cs
@@ -2,8 +2,8 @@
 {
     public class RobotsTxtSettings
     {
-        public int Mode { get; set; }
-
         public string CustomContent { get; set; }
+        public int Mode { get; set; }
+        public bool NoIndex { get; set; }
     }
 }

--- a/RobotsTxt/Startup.cs
+++ b/RobotsTxt/Startup.cs
@@ -8,6 +8,8 @@ using OrchardCore.Navigation;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Settings;
 using System;
+using Microsoft.AspNetCore.Mvc;
+using Etch.OrchardCore.SEO.RobotsTxt.Filters;
 
 namespace Etch.OrchardCore.SEO.RobotsTxt
 {
@@ -19,6 +21,11 @@ namespace Etch.OrchardCore.SEO.RobotsTxt
             services.AddScoped<INavigationProvider, AdminMenu>();
             services.AddScoped<IDisplayDriver<ISite>, RobotsTxtSettingsDisplayDriver>();
             services.AddScoped<IPermissionProvider, Permissions>();
+
+            services.Configure<MvcOptions>((options) =>
+            {
+                options.Filters.Add(typeof(NoIndexFilter));
+            });
         }
 
         public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)

--- a/RobotsTxt/ViewModels/RobosTxtSettingsViewModel.cs
+++ b/RobotsTxt/ViewModels/RobosTxtSettingsViewModel.cs
@@ -2,7 +2,8 @@
 {
     public class RobosTxtSettingsViewModel
     {
-        public int Mode { get; set; }
         public string CustomContent { get; set; }
+        public int Mode { get; set; }
+        public bool NoIndex { get; set; }
     }
 }

--- a/Views/RobotsTxtSettings.Edit.cshtml
+++ b/Views/RobotsTxtSettings.Edit.cshtml
@@ -23,6 +23,16 @@
     <span class="hint">@T["For more information on formatting robots.txt, visit <a href=\"https://robotstxt.org\">robotstxt.org</a>."]</span>
 </fieldset>
 
+<hr />
+
+<fieldset class="form-group" asp-validation-class-for="NoIndex">
+    <div class="custom-control custom-checkbox">
+        <input asp-for="NoIndex" type="checkbox" class="custom-control-input">
+        <label class="custom-control-label" asp-for="NoIndex">@T["Block search indexing with 'noindex'"]</label><br />
+        <span class="hint">@T["Prevent site from appearing in search engines by including <a href=\"https://developers.google.com/search/docs/advanced/crawling/block-indexing\">noindex response header</a>."]</span>
+    </div>
+</fieldset>
+
 <script type="text/javascript">
     document.onreadystatechange = function () {
         if (document.readyState != "interactive") {


### PR DESCRIPTION
Robots.txt settings now contains a flag to indicate whether search engines should be blocked via the `noindex` option. When enabled, all responses will contain the `x-Robots-Tag` header with the value of `noindex`.

Resolves #47.