### PR TITLE
Migration ordering

### DIFF
--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.7.2-rc2</Version>
+    <Version>0.7.3-rc2</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "SEO",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "0.7.2"
+    Version = "0.7.3"
 )]
 
 [assembly: Feature(

--- a/MetaTags/Migrations.cs
+++ b/MetaTags/Migrations.cs
@@ -31,7 +31,32 @@ namespace Etch.OrchardCore.SEO.MetaTags
 
             AddMetaTagFields();
 
-            return 1;
+            _contentDefinitionManager.AlterPartDefinition("MetaTagsPart", builder => builder
+                .WithField(Constants.CustomFieldName, field => field
+                    .OfType(typeof(DictionaryField).Name)
+                    .WithDisplayName(Constants.CustomFieldName)
+                    .WithPosition("5")
+                    .WithSettings(new DictionaryFieldSettings
+                    {
+                        Hint = "Apply custom meta tags that will override the defaults applied through defining image, title & description."
+                    })
+                )
+            );
+
+            _contentDefinitionManager.AlterPartDefinition("MetaTagsPart", builder => builder
+                .WithField(Constants.NoIndexFieldName, field => field
+                    .OfType(typeof(BooleanField).Name)
+                    .WithDisplayName(Constants.NoIndexFieldDisplayName)
+                    .WithPosition("4")
+                    .WithSettings(new BooleanFieldSettings
+                    {
+                        Label = "Hide from search engines",
+                        Hint = "Prevent page from appearing in search engines using 'noindex' meta tag.",
+                    })
+                )
+            );
+
+            return 5;
         }
 
         public int UpdateFrom1()
@@ -48,7 +73,7 @@ namespace Etch.OrchardCore.SEO.MetaTags
                 )
             );
 
-            return 4;
+            return 2;
         }
 
         public int UpdateFrom2()


### PR DESCRIPTION
When upgrading the module whose data migration version is at "1", it doesn't run the necessary migrations for converting the meta tag part fixed fields to content fields. This results in the front-end causing an exception because the content field isn't present as expected.