### PR TITLE
Use `BaseUrl` for hostname for various meta tags

### DIFF
--- a/MetaTags/Drivers/MetaTagsPartDisplay.cs
+++ b/MetaTags/Drivers/MetaTagsPartDisplay.cs
@@ -31,7 +31,7 @@ namespace Etch.OrchardCore.SEO.MetaTags.Drivers
         {
             if (context.DisplayType == "Detail")
             {
-                _metaTagsService.Register(part);
+                await _metaTagsService.RegisterAsync(part);
             }
 
             return await base.DisplayAsync(part, context);

--- a/MetaTags/Services/IMetaTagsService.cs
+++ b/MetaTags/Services/IMetaTagsService.cs
@@ -1,9 +1,10 @@
 ﻿using Etch.OrchardCore.SEO.MetaTags.Models;
+using System.Threading.Tasks;
 
 namespace Etch.OrchardCore.SEO.MetaTags.Services
 {
     public interface IMetaTagsService
     {
-        void Register(MetaTagsPart part);
+        Task RegisterAsync(MetaTagsPart part);
     }
 }


### PR DESCRIPTION
When a `BaseUrl` has been defined within the site settings, this value will be used for the hostname on meta tags that require the full URL within the value. When no `BaseUrl` is present it'll fallback to calculating the hostname via `Request`.