### PR TITLE
Default meta tags

### DIFF
--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "SEO",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "1.1.1"
+    Version = "1.2.0"
 )]
 
 [assembly: Feature(

--- a/MetaTags/AdminMenu.cs
+++ b/MetaTags/AdminMenu.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Localization;
+using OrchardCore.Navigation;
+using System;
+using System.Threading.Tasks;
+
+namespace Etch.OrchardCore.SEO.MetaTags
+{
+    public class AdminMenu : INavigationProvider
+    {
+        private readonly IStringLocalizer T;
+
+        public AdminMenu(IStringLocalizer<AdminMenu> localizer)
+        {
+            T = localizer;
+        }
+
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
+        {
+            if (!string.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.CompletedTask;
+            }
+
+            builder
+                .Add(T["Configuration"], configuration => configuration
+                    .Add(T["SEO"], settings => settings
+                        .Add(T["Default Meta Tags"], T["Default Meta Tags"], layers => layers
+                        .AddClass("metaTags").Id("metaTags")
+                            .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = "DefaultMetaTags" })
+                            .LocalNav()
+                        )));
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/MetaTags/Constants.cs
+++ b/MetaTags/Constants.cs
@@ -15,5 +15,15 @@
 
         public const string TitleFieldDisplayName = "Title";
         public const string TitleFieldName = "MetaTitle";
+
+        public static class Defaults
+        {
+            public const string ContentType = "DefaultMetaTags";
+
+            public const string Custom = "Custom";
+            public const string Description = "Description";
+            public const string Image = "Image";
+            public const string Title = "Title";
+        }
     }
 }

--- a/MetaTags/Extensions/MetaTagsPartExtensions.cs
+++ b/MetaTags/Extensions/MetaTagsPartExtensions.cs
@@ -11,19 +11,26 @@ namespace Etch.OrchardCore.SEO.MetaTags.Extensions
 {
     public static class MetaTagsPartExtensions
     {
-        public static IList<DictionaryItem> GetCustom(this MetaTagsPart part)
+        public static IList<DictionaryItem> GetCustom(this MetaTagsPart part, IList<DictionaryItem> defaults)
         {
-            return part.Get<DictionaryField>(Constants.CustomFieldName)?.Data;
+            var values = part.Get<DictionaryField>(Constants.CustomFieldName)?.Data ?? new List<DictionaryItem>();
+            
+            foreach (var customValue in defaults.Where(x => !values.Any(v => v.Name == x.Name)))
+            {
+                values.Add(customValue);
+            }
+            
+            return values;
         }
 
         public static string GetDescription(this MetaTagsPart part)
         {
-            return part?.Get<TextField>(Constants.DescriptionFieldName)?.Text ?? string.Empty;
+            return part?.Get<TextField>(Constants.DescriptionFieldName)?.Text ?? null;
         }
 
         public static string GetImage(this MetaTagsPart part)
         {
-            return part?.Get<MediaField>(Constants.ImageFieldName)?.Paths?.FirstOrDefault() ?? string.Empty;
+            return part?.Get<MediaField>(Constants.ImageFieldName)?.Paths?.FirstOrDefault() ?? null;
         }
 
         public static bool GetNoIndex(this MetaTagsPart part)
@@ -33,7 +40,7 @@ namespace Etch.OrchardCore.SEO.MetaTags.Extensions
 
         public static string GetTitle(this MetaTagsPart part)
         {
-            return part?.Get<TextField>(Constants.TitleFieldName)?.Text ?? string.Empty;
+            return part?.Get<TextField>(Constants.TitleFieldName)?.Text ?? null;
         }
 
         public static void UpdateDescription(this MetaTagsPart part, string description)

--- a/MetaTags/Migrations.cs
+++ b/MetaTags/Migrations.cs
@@ -106,6 +106,66 @@ namespace Etch.OrchardCore.SEO.MetaTags
             return 5;
         }
 
+        public int UpdateFrom5()
+        {
+            _contentDefinitionManager.AlterPartDefinition(Constants.Defaults.ContentType, builder => builder
+                .WithField(Constants.Defaults.Title, field => field
+                    .OfType(typeof(TextField).Name)
+                    .WithDisplayName(Constants.Defaults.Title)
+                    .WithPosition("1")
+                    .WithSettings(new TextFieldSettings
+                    {
+                        Hint = "Keep the your title around 60 characters and put the keywords you’re focusing on first. Don't go overboard with keywords, at most stick to two.",
+                    })
+                )
+            );
+
+            _contentDefinitionManager.AlterPartDefinition(Constants.Defaults.ContentType, builder => builder
+                .WithField(Constants.Defaults.Description, field => field
+                    .OfType(typeof(TextField).Name)
+                    .WithDisplayName(Constants.Defaults.Description)
+                    .WithPosition("2")
+                    .WithSettings(new TextFieldSettings
+                    {
+                        Hint = "The meta description often serves as a pitch to people who find your website on Google or social media sites. While it's not required and Google can use text from you website instead of what you specifiy in the meta data, it's better to control the description text where you can.",
+                    })
+                    .WithEditor("TextArea")
+                )
+            );
+
+            _contentDefinitionManager.AlterPartDefinition(Constants.Defaults.ContentType, builder => builder
+                .WithField(Constants.Defaults.Image, field => field
+                    .OfType(typeof(MediaField).Name)
+                    .WithDisplayName(Constants.Defaults.Image)
+                    .WithPosition("3")
+                    .WithSettings(new MediaFieldSettings
+                    {
+                        Hint = "With the visual nature of the web your Meta Tag Image is the most valuable graphic content you can create to encourage users to click and visit your website. Recommend 1200×628.",
+                        Multiple = false
+                    })
+                )
+            );
+
+            _contentDefinitionManager.AlterPartDefinition(Constants.Defaults.ContentType, builder => builder
+                .WithField(Constants.Defaults.Custom, field => field
+                    .OfType(typeof(DictionaryField).Name)
+                    .WithDisplayName(Constants.Defaults.Custom)
+                    .WithPosition("5")
+                    .WithSettings(new DictionaryFieldSettings
+                    {
+                        Hint = "Apply custom meta tags that will override the defaults applied through defining image, title & description."
+                    })
+                )
+            );
+
+            _contentDefinitionManager.AlterTypeDefinition(Constants.Defaults.ContentType, builder => builder
+                .Stereotype("CustomSettings")
+                .DisplayedAs("Default Meta Tags")
+                .WithPart(Constants.Defaults.ContentType));
+
+            return 6;
+        }
+
         private void AddMetaTagFields()
         {
             _contentDefinitionManager.AlterPartDefinition("MetaTagsPart", builder => builder

--- a/MetaTags/Migrations.cs
+++ b/MetaTags/Migrations.cs
@@ -115,7 +115,7 @@ namespace Etch.OrchardCore.SEO.MetaTags
                     .WithPosition("1")
                     .WithSettings(new TextFieldSettings
                     {
-                        Hint = "Keep the your title around 60 characters and put the keywords you’re focusing on first. Don't go overboard with keywords, at most stick to two.",
+                        Hint = "Keep your title around 60 characters and put the keywords you’re focusing on first. Don't go overboard with keywords, at most stick to two.",
                     })
                 )
             );
@@ -127,7 +127,7 @@ namespace Etch.OrchardCore.SEO.MetaTags
                     .WithPosition("2")
                     .WithSettings(new TextFieldSettings
                     {
-                        Hint = "The meta description often serves as a pitch to people who find your website on Google or social media sites. While it's not required and Google can use text from you website instead of what you specifiy in the meta data, it's better to control the description text where you can.",
+                        Hint = "The meta description often serves as a pitch to people who find your website on Google or social media sites. While it's not required and Google can use text from you website instead of what you specify in the meta data, it's better to control the description text where you can.",
                     })
                     .WithEditor("TextArea")
                 )
@@ -175,7 +175,7 @@ namespace Etch.OrchardCore.SEO.MetaTags
                     .WithPosition("1")
                     .WithSettings(new TextFieldSettings
                     {
-                        Hint = "Keep the your title around 60 characters and put the keywords you’re focusing on first. Don't go overboard with keywords, at most stick to two.",
+                        Hint = "Keep your title around 60 characters and put the keywords you’re focusing on first. Don't go overboard with keywords, at most stick to two.",
                     })
                 )
             );
@@ -187,7 +187,7 @@ namespace Etch.OrchardCore.SEO.MetaTags
                     .WithPosition("2")
                     .WithSettings(new TextFieldSettings
                     {
-                        Hint = "The meta description often serves as a pitch to people who find your website on Google or social media sites. While it's not required and Google can use text from you website instead of what you specifiy in the meta data, it's better to control the description text where you can.",
+                        Hint = "The meta description often serves as a pitch to people who find your website on Google or social media sites. While it's not required and Google can use text from you website instead of what you specify in the meta data, it's better to control the description text where you can.",
                     })
                     .WithEditor("TextArea")
                 )

--- a/MetaTags/Settings/DefaultMetaTags.cs
+++ b/MetaTags/Settings/DefaultMetaTags.cs
@@ -1,0 +1,13 @@
+﻿using Etch.OrchardCore.Fields.Dictionary.Models;
+using System.Collections.Generic;
+
+namespace Etch.OrchardCore.SEO.MetaTags.Settings
+{
+    public class DefaultMetaTags
+    {
+        public IList<DictionaryItem> Custom { get; set; }
+        public string Description { get; set; }
+        public string ImagePath { get; set; }
+        public string Title { get; set; }
+    }
+}

--- a/MetaTags/Startup.cs
+++ b/MetaTags/Startup.cs
@@ -6,6 +6,7 @@ using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.Data.Migration;
 using OrchardCore.Modules;
+using OrchardCore.Navigation;
 
 namespace Etch.OrchardCore.SEO.MetaTags
 {
@@ -14,6 +15,8 @@ namespace Etch.OrchardCore.SEO.MetaTags
     {
         public override void ConfigureServices(IServiceCollection services)
         {
+            services.AddScoped<INavigationProvider, AdminMenu>();
+
             services.AddContentPart<MetaTagsPart>()
                 .UseDisplayDriver<MetaTagsPartDisplay>();
 

--- a/RobotsTxt/AdminMenu.cs
+++ b/RobotsTxt/AdminMenu.cs
@@ -28,6 +28,7 @@ namespace Etch.OrchardCore.SEO.RobotsTxt
                 .Add(T["Configuration"], configuration => configuration
                     .Add(T["SEO"], settings => settings
                         .Add(T["Robots.txt"], T["Robots.txt"], layers => layers
+                        .AddClass("robots").Id("robots")
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = RobotsTxtSettingsDisplayDriver.GroupId })
                             .Permission(Permissions.ManageRobotsTxt)
                             .LocalNav()

--- a/Views/NavigationItemText-metaTags.Id.cshtml
+++ b/Views/NavigationItemText-metaTags.Id.cshtml
@@ -1,0 +1,1 @@
+﻿<span class="icon"><i class="fa fa-tags" aria-hidden="true"></i></span><span class="title">@T["Default Meta Tags"]</span> 

--- a/Views/NavigationItemText-robots.Id.cshtml
+++ b/Views/NavigationItemText-robots.Id.cshtml
@@ -1,0 +1,1 @@
+﻿<span class="icon"><i class="fa fa-robot" aria-hidden="true"></i></span><span class="title">@T["Robots.txt"]</span> 


### PR DESCRIPTION
Added new content type, "DefaultMetaTags" that has the same fields as the `MetaTagsPart`. When determining the meta tags that should be  rendered, if none are specified on the part then it'll use the ones defined with the custom settings.