### PR TITLE
Fix migration issue

### DIFF
--- a/Etch.OrchardCore.SEO.csproj
+++ b/Etch.OrchardCore.SEO.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <PackageId>Etch.OrchardCore.SEO</PackageId>
     <Title>Etch OrchardCore SEO</Title>
     <Authors>Etch</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -49,6 +49,7 @@ using OrchardCore.Modules.Manifest;
     Name = "Meta Tags",
     Dependencies = new[]
     {
+        "OrchardCore.Autoroute",
         "Etch.OrchardCore.Fields.Dictionary",
         "OrchardCore.Media"
     },

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "SEO",
     Author = "Etch",
     Website = "https://etchuk.com",
-    Version = "1.1.0"
+    Version = "1.1.1"
 )]
 
 [assembly: Feature(


### PR DESCRIPTION
Noticed an issue when upgrading a site recently that would cause an exception because the `Autouroute` migration has not been able to run before a query is made to get content items that need their meta data updated. Solution is to add a dependency to `OrchardCore.Autoroute` to ensure that migration is executed before the SEO migrations.